### PR TITLE
Add alternative views for organization activity and pass through growth + timestamp

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/01_materialized_views/02_organization_activity/01_create_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/01_materialized_views/02_organization_activity/01_create_view.sql
@@ -3,23 +3,31 @@ DROP MATERIALIZED VIEW IF EXISTS organization_activity CASCADE;
 CREATE MATERIALIZED VIEW organization_activity AS (
     SELECT
         timescale,
+        timestamp,
         period,
         role,
         CONCAT('us-', organization_id) AS organization_id,
         annotation_count,
+        annotation_count_growth,
         active,
-        billable
+        active_growth,
+        billable,
+        billable_growth
     FROM lms_us.organization_activity
 
     UNION ALL
 
     SELECT
         timescale,
+        timestamp,
         period,
         role,
         CONCAT('ca-', organization_id) AS organization_id,
         annotation_count,
+        annotation_count_growth,
         active,
-        billable
+        active_growth,
+        billable,
+        billable_growth
     FROM lms_ca.organization_activity
 ) WITH NO DATA;

--- a/report/sql_tasks/tasks/report/create_from_scratch/01_materialized_views/02_organization_activity/03_create_flat_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/01_materialized_views/02_organization_activity/03_create_flat_view.sql
@@ -1,0 +1,30 @@
+-- A full flattened view of the activity counts where each type of count
+-- for teachers and users is in a separate column. This allows for easier
+-- comparison of metrics in the same graph / table etc.
+CREATE VIEW organization_activity_flat AS (
+    SELECT
+        user_activity.timescale,
+        user_activity.timestamp,
+        user_activity.period,
+        user_activity.organization_id,
+
+        user_activity.annotation_count,
+        user_activity.annotation_count_growth,
+        user_activity.active AS active_users,
+        user_activity.active_growth AS active_user_growth,
+        user_activity.billable AS billable_users,
+        user_activity.billable_growth AS billable_user_growth,
+
+        teacher_activity.active AS active_teachers,
+        teacher_activity.active_growth AS active_teacher_growth,
+        teacher_activity.billable AS billable_teachers,
+        teacher_activity.billable_growth AS billable_teacher_growth
+    FROM organization_activity AS user_activity
+    JOIN organization_activity AS teacher_activity ON
+        teacher_activity.timescale = user_activity.timescale
+        AND teacher_activity.period = user_activity.period
+        AND teacher_activity.organization_id = user_activity.organization_id
+        AND teacher_activity.role = 'teacher'
+    WHERE
+        user_activity.role = 'user'
+);

--- a/report/sql_tasks/tasks/report/create_from_scratch/01_materialized_views/02_organization_activity/04_create_serial_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/01_materialized_views/02_organization_activity/04_create_serial_view.sql
@@ -1,0 +1,49 @@
+DROP TYPE IF EXISTS report.activity_metric CASCADE;
+
+CREATE TYPE report.activity_metric AS ENUM (
+    'annotation', 'billable', 'active'
+);
+
+-- A full serial view of the activity counts where each type of count
+-- for teachers and users and metric is selectable from a single column. This
+-- allows for more easy switching between metrics using a drop down.
+CREATE VIEW organization_activity_serial AS (
+    SELECT
+        timescale,
+        timestamp,
+        period,
+        role,
+        'annotation'::report.activity_metric AS metric,
+        organization_id,
+        annotation_count AS count,
+        annotation_count_growth AS growth
+    FROM organization_activity
+    -- We don't yet track teacher annotation counts
+    WHERE role = 'user'
+
+    UNION ALL
+
+    SELECT
+        timescale,
+        timestamp,
+        period,
+        role,
+        'active'::report.activity_metric AS metric,
+        organization_id,
+        active AS count,
+        active_growth AS growth
+    FROM organization_activity
+
+    UNION ALL
+
+    SELECT
+        timescale,
+        timestamp,
+        period,
+        role,
+        'billable'::report.activity_metric AS metric,
+        organization_id,
+        billable AS count,
+        billable_growth AS growth
+    FROM organization_activity
+);


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/4

Requires:

 * https://github.com/hypothesis/lms/pull/4616

This passes through the growth metrics and timestamp column on the activity reports.

This also adds views to allow easier presentation or comparison of the same data depending on situation. This is because it's much easier to present the data in Metabase in different contexts if it's very row or column centric.

* Having all the data with facets in columns allows for easily mutatable graphs where users can chose the facets from drop downs
* Having all the data in separate columns makes it easier to show and compare multiple types of data in the same table

## Testing notes

 * Follow the testing notes in https://github.com/hypothesis/lms/pull/4616
 * `make services`
 * `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch"`
 * We seem to be missing `make sql`? But you can use:
 * `psql postgresql://postgres@localhost:5436/postgres`
 * `select * from organization_activity_flat;`