### PR TITLE
Set the refresh job to run 30 minutes after LMS

### DIFF
--- a/.github/workflows/report_refresh.yml
+++ b/.github/workflows/report_refresh.yml
@@ -3,8 +3,8 @@
 name: Report refresh
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: '0 14 * * *'
+  schedule:
+    - cron: '0 16 * * *'
 
 jobs:
   refresh:
@@ -12,7 +12,7 @@ jobs:
     uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
     with:
       App: ${{ github.event.repository.name }}
-      Env: 'qa'
+      Env: 'prod'
       Timeout: 3600
       Region: 'us-west-1'
       Command: 'python bin/run_sql_task.py --task report/refresh'


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/4

Trigger the refresh job to happen 30 minutes after the LMS one. We can tweak the time eventually, but it's intended to run during times we will be around to see it fail (rather than waking someone up).

This will make it less reliable as people will probably disrupt it with deploys, but we can fix that later.