### PR TITLE
Add a block to the refresh to trigger imports from Hubspot

### DIFF
--- a/.github/workflows/imports.yml
+++ b/.github/workflows/imports.yml
@@ -38,7 +38,7 @@ jobs:
 
   hubspot:
     needs: check_for_danger
-    name: "Imports hubspot data into the report's DB"
+    name: "Import Hubspot data into the report's DB"
     uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
     with:
       App: ${{ github.event.repository.name }}

--- a/.github/workflows/report_refresh.yml
+++ b/.github/workflows/report_refresh.yml
@@ -7,7 +7,19 @@ on:
     - cron: '0 16 * * *'
 
 jobs:
+  hubspot:
+    name: "Import Hubspot data into the report's DB"
+    uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
+    with:
+      App: ${{ github.event.repository.name }}
+      Env: 'prod'
+      Timeout: 3600
+      Region: 'us-west-1'
+      Command: 'python bin/hubspot_import.py'
+    secrets: inherit
+
   refresh:
+    needs: hubspot
     name: "Update report information"
     uses: hypothesis/workflows/.github/workflows/eb-task.yml@main
     with:


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/4

I'm not sure if this is the best way to do it, as we'll probably waste a bit of time we could avoid by chaining the two commands in the same execution, but this feels like it will give better feedback if a stage fails.