### PR TITLE
Reduce metabase logging verbosity

### DIFF
--- a/.cookiecutter/includes/README/head.md
+++ b/.cookiecutter/includes/README/head.md
@@ -21,6 +21,11 @@ On top of the service own environment variables these are the metabase variables
 | `MB_DB_TYPE`                    | `postgres`        | Metabase database type. We use `postgres`. |
 | `MB_DB_USER`                    | `user`        | Metabase database user                                   |
 
+In addition, we are also providing some custom Java options
+
+| Name           | Value                                                | Description           |
+|----------------|------------------------------------------------------|-----------------------|
+| `JAVA_OPTS`    |-Dlog4j.configurationFile=file://conf/report-log4j2.xml| Custom log4j config   |
 
 The full list of supported variables by metabase can be found here:
 

--- a/conf/report-log4j2.xml
+++ b/conf/report-log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
+      <PatternLayout pattern="%date %level %logger{2} :: %message%n%throwable">
+        <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="metabase" level="ERROR"/>
+    <Logger name="metabase-enterprise" level="ERROR"/>
+    <Logger name="metabase.plugins" level="ERROR"/>
+    <Logger name="metabase.server.middleware" level="ERROR"/>
+    <Logger name="metabase.query-processor.async" level="ERROR"/>
+    <Logger name="com.mchange" level="ERROR"/>
+    <Logger name="org.quartz" level="ERROR"/>
+    <Logger name="liquibase" level="ERROR"/>
+
+    <Root level="ERROR">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
In it's default form Metabase logging is crazy verbose. This commit aims to fix that.

A custom log4j2 configuration is provided to default the logging level to `ERROR`.

To activate the logging the following env var needs to be set.
```
JAVA_OPTS=-Dlog4j.configurationFile=file://conf/report-log4j2.xml
```

####  References
https://www.metabase.com/docs/latest/configuring-metabase/log-configuration.html
https://logging.apache.org/log4j/2.x/manual/customloglevels.html
[default metabase log4j2.xml](https://github.com/metabase/metabase/blob/a8816bccd1e53ec842a93f980affe679e86190b6/resources/log4j2.xml)
