### PR TITLE
Allow empty SQL scripts

### DIFF
--- a/report/sql_tasks/sql_script.py
+++ b/report/sql_tasks/sql_script.py
@@ -62,11 +62,9 @@ class SQLScript:
                 self.template_vars
             )
 
-        if not sqlparse.format(script_text, strip_comments=True).strip():
-            # The file is empty or only contains comments
-            return []
-
         return [
             SQLQuery(text=query, index=index)
             for index, query in (enumerate(sqlparse.split(script_text)))
+            # Skip any empty queries
+            if sqlparse.format(query, strip_comments=True).strip()
         ]

--- a/tests/unit/report/sql_tasks/loader_test.py
+++ b/tests/unit/report/sql_tasks/loader_test.py
@@ -41,6 +41,11 @@ class TestTask:
                 template_vars=template_vars,
                 queries=[],
             ),
+            SQLScript(
+                path=str(fixture_dir / "06_trailing_comment.sql"),
+                template_vars=template_vars,
+                queries=[SQLQuery(index=0, text="-- Comment\nSELECT 1;")],
+            ),
         ]
 
     def test_from_dir_raises_for_missing_dir(self):

--- a/tests/unit/report/sql_tasks/loader_test.py
+++ b/tests/unit/report/sql_tasks/loader_test.py
@@ -36,6 +36,11 @@ class TestTask:
                 queries=[SQLQuery(index=0, text="SELECT 'template_value';")],
             ),
             PythonScript(path=str(fixture_dir / "04_file.py"), module=Any()),
+            SQLScript(
+                path=str(fixture_dir / "05_empty.sql"),
+                template_vars=template_vars,
+                queries=[],
+            ),
         ]
 
     def test_from_dir_raises_for_missing_dir(self):

--- a/tests/unit/report/sql_tasks/script_fixture/05_empty.sql
+++ b/tests/unit/report/sql_tasks/script_fixture/05_empty.sql
@@ -1,0 +1,1 @@
+-- Just a comment here

--- a/tests/unit/report/sql_tasks/script_fixture/06_trailing_comment.sql
+++ b/tests/unit/report/sql_tasks/script_fixture/06_trailing_comment.sql
@@ -1,0 +1,3 @@
+-- Comment
+SELECT 1;
+-- Comment after query, parsed as its own query


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/47

Probably not very common for regular .sql files but templated ones might get empty depending of the variables' values


## Testing

- Make a change similar to

```diff
 --git a/report/sql_tasks/tasks/report/refresh/02_hubspot.sql b/report/sql_tasks/tasks/report/refresh/02_hubspot.sql
index 8ea09e0..ec8c7b1 100644
--- a/report/sql_tasks/tasks/report/refresh/02_hubspot.sql
+++ b/report/sql_tasks/tasks/report/refresh/02_hubspot.sql
@@ -1,3 +1,3 @@
-REFRESH MATERIALIZED VIEW CONCURRENTLY hubspot.company_activity;
+--REFRESH MATERIALIZED VIEW CONCURRENTLY hubspot.company_activity;
 
-ANALYSE hubspot.company_activity;
\ No newline at end of file
+-- ANALYSE hubspot.company_activity;
```


- Run `tox -qe dev --run-command 'python bin/run_sql_task.py  -t report/refresh'`

and get:

```
   SQL script: '/home/marcos/hypo/report/report/sql_tasks/tasks/report/refresh/02_hubspot.sql'
    Executed 0 queries
    Done in: 0:00:00.000003

```
