### PR TITLE
Try and dedupe deal company relations, which don't seem to be unique

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/02_hubspot/01_tables/02_create_deal_table.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/02_hubspot/01_tables/02_create_deal_table.sql
@@ -2,10 +2,7 @@ DROP TABLE IF EXISTS hubspot.deals CASCADE;
 
 CREATE TABLE hubspot.deals (
     id BIGINT PRIMARY KEY,
-    company_id BIGINT,
     services_start DATE,
     services_end DATE,
     amount FLOAT
 );
-
-CREATE INDEX deals_company_id_idx ON hubspot.deals (company_id);

--- a/report/sql_tasks/tasks/report/create_from_scratch/02_hubspot/01_tables/03_company_deals_table.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/02_hubspot/01_tables/03_company_deals_table.sql
@@ -4,3 +4,5 @@ CREATE TABLE hubspot.company_deals (
     company_id BIGINT NOT NULL,
     deal_id BIGINT NOT NULL
 );
+
+CREATE UNIQUE INDEX company_deals_company_id_deal_id_idx ON hubspot.company_deals (company_id, deal_id);


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/50

This is to try and work around a uniqueness constraint issue we are getting. 

I've reworked this PR to:

 * Dedupe object id inputs inside the Hubspot client `get_associations` method
 * Dedupe the outputs too
 * Put back the index
 * Remove a rogue column that was left behind in previous work