### PR TITLE
Add Sentry to the SQL task runner

### DIFF
--- a/.cookiecutter/includes/README/head.md
+++ b/.cookiecutter/includes/README/head.md
@@ -2,29 +2,32 @@ Used for internal purposes only.
 
 ## Environment variables
 
-
-| Name                              | Example                                | Notes                                           | 
-|-----------------------------------|----------------------------------------|-------------------------------------------------|
-| `DATABASE_URL`                    | `postgresql://user:pw@host/report`        | Postgres DSN for the report DB                                   |
-
+| Name                    | Example                                | Notes                                                  |
+|-------------------------|----------------------------------------|--------------------------------------------------------|
+| `DATABASE_URL`          | `postgresql://user:pw@host/report`     | Postgres DSN for the report DB                         |
+| `HUBSPOT_API_KEY`       | `01234567-89ab-cdef-0123-456789abcdef` | API key for integration with Hubspot                   |
+| `H_CA_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (Canada)                               |
+| `H_US_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (US)                                   |
+| `LMS_CA_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (Canada)                             |
+| `LMS_US_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (US)                                 |
+| `MB_DB_USER`            | `metabase`                             | The username Metabase will use to access the report DB |
 
 On top of the service own environment variables these are the metabase variables that we use:
 
-
-| Name                              | Example                                | Notes                                           | 
-|-----------------------------------|----------------------------------------|-------------------------------------------------|
-| `MB_DB_DBNAME`                    | `metabase`        | Metabase database name                                   |
-| `MB_DB_HOST`                    | `localhost`        | Metabase database host                                   |
-| `MB_DB_PASS`                    | `pass`        | Metabase database password                                   |
-| `MB_DB_PORT`                    | `5432`        | Metabase database port                                   |
-| `MB_DB_TYPE`                    | `postgres`        | Metabase database type. We use `postgres`. |
-| `MB_DB_USER`                    | `user`        | Metabase database user                                   |
+| Name           | Example     | Notes                                      |
+|----------------|-------------|--------------------------------------------|
+| `MB_DB_DBNAME` | `metabase`  | Metabase database name                     |
+| `MB_DB_HOST`   | `localhost` | Metabase database host                     |
+| `MB_DB_PASS`   | `pass`      | Metabase database password                 |
+| `MB_DB_PORT`   | `5432`      | Metabase database port                     |
+| `MB_DB_TYPE`   | `postgres`  | Metabase database type. We use `postgres`. |
+| `MB_DB_USER`   | `user`      | Metabase database user                     |
 
 In addition, we are also providing some custom Java options
 
-| Name           | Value                                                | Description           |
-|----------------|------------------------------------------------------|-----------------------|
-| `JAVA_OPTS`    |-Dlog4j.configurationFile=file://conf/report-log4j2.xml| Custom log4j config   |
+| Name        | Value                                                     | Description         |
+|-------------|-----------------------------------------------------------|---------------------|
+| `JAVA_OPTS` | `-Dlog4j.configurationFile=file://conf/report-log4j2.xml` | Custom log4j config |
 
 The full list of supported variables by metabase can be found here:
 

--- a/.cookiecutter/includes/README/head.md
+++ b/.cookiecutter/includes/README/head.md
@@ -2,15 +2,17 @@ Used for internal purposes only.
 
 ## Environment variables
 
-| Name                    | Example                                | Notes                                                  |
-|-------------------------|----------------------------------------|--------------------------------------------------------|
-| `DATABASE_URL`          | `postgresql://user:pw@host/report`     | Postgres DSN for the report DB                         |
-| `HUBSPOT_API_KEY`       | `01234567-89ab-cdef-0123-456789abcdef` | API key for integration with Hubspot                   |
-| `H_CA_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (Canada)                               |
-| `H_US_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (US)                                   |
-| `LMS_CA_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (Canada)                             |
-| `LMS_US_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (US)                                 |
-| `MB_DB_USER`            | `metabase`                             | The username Metabase will use to access the report DB |
+| Name                  | Example                                | Notes                                                  |
+|-----------------------|----------------------------------------|--------------------------------------------------------|
+| `DATABASE_URL`        | `postgresql://user:pw@host/report`     | Postgres DSN for the report DB                         |
+| `HUBSPOT_API_KEY`     | `01234567-89ab-cdef-0123-456789abcdef` | API key for integration with Hubspot                   |
+| `H_CA_DATABASE_URL`   | `postgresql://user:pw@host/h`          | Connection to H (Canada)                               |
+| `H_US_DATABASE_URL`   | `postgresql://user:pw@host/h`          | Connection to H (US)                                   |
+| `LMS_CA_DATABASE_URL` | `postgresql://user:pw@host/lms`        | Connection to LMS (Canada)                             |
+| `LMS_US_DATABASE_URL` | `postgresql://user:pw@host/lms`        | Connection to LMS (US)                                 |
+| `MB_DB_USER`          | `metabase`                             | The username Metabase will use to access the report DB |
+| `SENTRY_DSN`          | `01234567-89ab-cdef-0123-456789abcdef` | Connection details for Sentry error reporting          |
+| `SENTRY_ENVIRONMENT`  | `prod`                                 | The Sentry environment                                 |
 
 On top of the service own environment variables these are the metabase variables that we use:
 

--- a/.cookiecutter/includes/requirements/prod.in
+++ b/.cookiecutter/includes/requirements/prod.in
@@ -1,9 +1,11 @@
+# From .cookiecutter/includes/requirements/prod.in:
 newrelic
 
 hubspot-api-client
 importlib_resources
 jinja2
 psycopg2
+sentry-sdk
 SQLAlchemy
 sqlparse
 tabulate

--- a/.cookiecutter/includes/tox/passenv
+++ b/.cookiecutter/includes/tox/passenv
@@ -1,2 +1,4 @@
+# From .cookiecutter/includes/tox/passenv:
 HUBSPOT_API_KEY
+SENTRY_DSN
 TEST_DATABASE_URL

--- a/.cookiecutter/includes/tox/setenv
+++ b/.cookiecutter/includes/tox/setenv
@@ -1,3 +1,4 @@
+# From .cookiecutter/includes/tox/setenv:
 MB_DB_USER = {env:MB_DB_USER:postgres}
 # As it's Postgres itself that will be contacting these DBs, this will
 # happen inside docker, so we use docker names here
@@ -5,3 +6,4 @@ H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://postgres:postgres@h_post
 H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
 LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
 LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
+dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}

--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,12 @@ checkformatting: python
 
 .PHONY: test
 $(call help,make test,"run the unit tests in Python 3.8")
-coverage: test
 test: python
 	@pyenv exec tox -qe tests
 
 .PHONY: coverage
 $(call help,make coverage,"run the tests and print the coverage report")
-coverage: python
-	@pyenv exec tox -qe coverage
-
+coverage: python	@pyenv exec tox --parallel -qe 'tests,py{}-tests,coverage'
 .PHONY: functests
 $(call help,make functests,"run the functional tests in Python 3.8")
 functests: python

--- a/README.md
+++ b/README.md
@@ -12,47 +12,17 @@ Used for internal purposes only.
 
 ## Environment variables
 
-
-| Name                              | Example                                | Notes                                           | 
-|-----------------------------------|----------------------------------------|-------------------------------------------------|
-| `DATABASE_URL`                    | `postgresql://user:pw@host/report`        | Postgres DSN for the report DB                                   |
-
-
-On top of the service own environment variables these are the metabase variables that we use:
-
-
-| Name                              | Example                                | Notes                                           | 
-|-----------------------------------|----------------------------------------|-------------------------------------------------|
-| `MB_DB_DBNAME`                    | `metabase`        | Metabase database name                                   |
-| `MB_DB_HOST`                    | `localhost`        | Metabase database host                                   |
-| `MB_DB_PASS`                    | `pass`        | Metabase database password                                   |
-| `MB_DB_PORT`                    | `5432`        | Metabase database port                                   |
-| `MB_DB_TYPE`                    | `postgres`        | Metabase database type. We use `postgres`. |
-| `MB_DB_USER`                    | `user`        | Metabase database user                                   |
-
-In addition, we are also providing some custom Java options
-
-| Name           | Value                                                | Description           |
-|----------------|------------------------------------------------------|-----------------------|
-| `JAVA_OPTS`    |-Dlog4j.configurationFile=file://conf/report-log4j2.xml| Custom log4j config   |
-
-The full list of supported variables by metabase can be found here:
-
-https://www.metabase.com/docs/latest/configuring-metabase/environment-variables.html
-
-Used for internal purposes only.
-
-## Environment variables
-
-| Name                    | Example                                | Notes                                                  |
-|-------------------------|----------------------------------------|--------------------------------------------------------|
-| `DATABASE_URL`          | `postgresql://user:pw@host/report`     | Postgres DSN for the report DB                         |
-| `HUBSPOT_API_KEY`       | `01234567-89ab-cdef-0123-456789abcdef` | API key for integration with Hubspot                   |
-| `H_CA_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (Canada)                               |
-| `H_US_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (US)                                   |
-| `LMS_CA_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (Canada)                             |
-| `LMS_US_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (US)                                 |
-| `MB_DB_USER`            | `metabase`                             | The username Metabase will use to access the report DB |
+| Name                  | Example                                | Notes                                                  |
+|-----------------------|----------------------------------------|--------------------------------------------------------|
+| `DATABASE_URL`        | `postgresql://user:pw@host/report`     | Postgres DSN for the report DB                         |
+| `HUBSPOT_API_KEY`     | `01234567-89ab-cdef-0123-456789abcdef` | API key for integration with Hubspot                   |
+| `H_CA_DATABASE_URL`   | `postgresql://user:pw@host/h`          | Connection to H (Canada)                               |
+| `H_US_DATABASE_URL`   | `postgresql://user:pw@host/h`          | Connection to H (US)                                   |
+| `LMS_CA_DATABASE_URL` | `postgresql://user:pw@host/lms`        | Connection to LMS (Canada)                             |
+| `LMS_US_DATABASE_URL` | `postgresql://user:pw@host/lms`        | Connection to LMS (US)                                 |
+| `MB_DB_USER`          | `metabase`                             | The username Metabase will use to access the report DB |
+| `SENTRY_DSN`          | `01234567-89ab-cdef-0123-456789abcdef` | Connection details for Sentry error reporting          |
+| `SENTRY_ENVIRONMENT`  | `prod`                                 | The Sentry environment                                 |
 
 On top of the service own environment variables these are the metabase variables that we use:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,41 @@ The full list of supported variables by metabase can be found here:
 
 https://www.metabase.com/docs/latest/configuring-metabase/environment-variables.html
 
+Used for internal purposes only.
+
+## Environment variables
+
+| Name                    | Example                                | Notes                                                  |
+|-------------------------|----------------------------------------|--------------------------------------------------------|
+| `DATABASE_URL`          | `postgresql://user:pw@host/report`     | Postgres DSN for the report DB                         |
+| `HUBSPOT_API_KEY`       | `01234567-89ab-cdef-0123-456789abcdef` | API key for integration with Hubspot                   |
+| `H_CA_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (Canada)                               |
+| `H_US_DATABASE_URL`     | `postgresql://user:pw@host/h`          | Connection to H (US)                                   |
+| `LMS_CA_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (Canada)                             |
+| `LMS_US_DATABASE_URL`   | `postgresql://user:pw@host/lms`        | Connection to LMS (US)                                 |
+| `MB_DB_USER`            | `metabase`                             | The username Metabase will use to access the report DB |
+
+On top of the service own environment variables these are the metabase variables that we use:
+
+| Name           | Example     | Notes                                      |
+|----------------|-------------|--------------------------------------------|
+| `MB_DB_DBNAME` | `metabase`  | Metabase database name                     |
+| `MB_DB_HOST`   | `localhost` | Metabase database host                     |
+| `MB_DB_PASS`   | `pass`      | Metabase database password                 |
+| `MB_DB_PORT`   | `5432`      | Metabase database port                     |
+| `MB_DB_TYPE`   | `postgres`  | Metabase database type. We use `postgres`. |
+| `MB_DB_USER`   | `user`      | Metabase database user                     |
+
+In addition, we are also providing some custom Java options
+
+| Name        | Value                                                     | Description         |
+|-------------|-----------------------------------------------------------|---------------------|
+| `JAVA_OPTS` | `-Dlog4j.configurationFile=file://conf/report-log4j2.xml` | Custom log4j config |
+
+The full list of supported variables by metabase can be found here:
+
+https://www.metabase.com/docs/latest/configuring-metabase/environment-variables.html
+
 ## Setting up Your Report Development Environment
 
 First you'll need to install:

--- a/bin/run_sql_task.py
+++ b/bin/run_sql_task.py
@@ -14,6 +14,7 @@ import sqlalchemy
 from psycopg2.extensions import parse_dsn
 
 from report import sql_tasks
+from report.sentry import load_sentry
 from report.sql_tasks.python_script import PythonScript
 
 TASK_ROOT = importlib_resources.files("report.sql_tasks") / "tasks"
@@ -36,6 +37,8 @@ def _get_dsn(env_var_name):
 
 
 def main():
+    load_sentry()
+
     args = parser.parse_args()
     dsn = _get_dsn("DATABASE_URL")
 

--- a/report/sentry.py
+++ b/report/sentry.py
@@ -1,0 +1,10 @@
+import os
+
+import sentry_sdk
+
+
+def load_sentry():
+    """Load Sentry integration."""
+
+    if sentry_dsn := os.environ.get("SENTRY_DSN"):
+        sentry_sdk.init(dsn=sentry_dsn)

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -6,7 +6,7 @@
 #
 black==22.10.0
     # via -r requirements/checkformatting.in
-build==0.8.0
+build==0.9.0
     # via pip-tools
 click==8.1.3
     # via
@@ -18,13 +18,13 @@ mypy-extensions==0.4.3
     # via black
 packaging==21.3
     # via build
-pathspec==0.10.1
+pathspec==0.10.2
     # via black
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/checkformatting.in
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via black
 pyparsing==3.0.9
     # via packaging
@@ -35,11 +35,11 @@ tomli==2.0.1
     #   pep517
 typing-extensions==4.4.0
     # via black
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via pip-tools

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe requirements/coverage.in
 #
-build==0.8.0
+build==0.9.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
@@ -14,7 +14,7 @@ packaging==21.3
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/coverage.in
 pyparsing==3.0.9
     # via packaging
@@ -23,11 +23,11 @@ tomli==2.0.1
     #   build
     #   coverage
     #   pep517
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,12 +8,13 @@ asttokens==2.1.0
     # via stack-data
 backcall==0.2.0
     # via ipython
-build==0.8.0
+build==0.9.0
     # via pip-tools
 certifi==2022.9.24
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
+    #   sentry-sdk
 click==8.1.3
     # via pip-tools
 decorator==5.1.1
@@ -24,11 +25,11 @@ factory-boy==3.2.1
     # via -r requirements/dev.in
 faker==15.3.2
     # via factory-boy
-greenlet==1.1.3.post0
+greenlet==2.0.1
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
-hubspot-api-client==6.1.0
+hubspot-api-client==7.0.0
     # via -r requirements/prod.txt
 importlib-resources==5.10.0
     # via -r requirements/prod.txt
@@ -56,7 +57,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/dev.in
 prompt-toolkit==3.0.32
     # via ipython
@@ -75,13 +76,15 @@ python-dateutil==2.8.2
     #   -r requirements/prod.txt
     #   faker
     #   hubspot-api-client
+sentry-sdk==1.11.0
+    # via -r requirements/prod.txt
 six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   asttokens
     #   hubspot-api-client
     #   python-dateutil
-sqlalchemy==1.4.42
+sqlalchemy==1.4.44
     # via -r requirements/prod.txt
 sqlparse==0.4.3
     # via -r requirements/prod.txt
@@ -103,9 +106,10 @@ urllib3==1.26.12
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
+    #   sentry-sdk
 wcwidth==0.2.5
     # via prompt-toolkit
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 zipp==3.10.0
     # via
@@ -113,9 +117,9 @@ zipp==3.10.0
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via
     #   pip-tools
     #   supervisor

--- a/requirements/dockercompose.txt
+++ b/requirements/dockercompose.txt
@@ -8,7 +8,7 @@ attrs==22.1.0
     # via jsonschema
 bcrypt==4.0.1
     # via paramiko
-build==0.8.0
+build==0.9.0
     # via pip-tools
 certifi==2022.9.24
     # via requests
@@ -20,11 +20,11 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via pip-tools
-cryptography==38.0.1
+cryptography==38.0.3
     # via paramiko
 distro==1.8.0
     # via docker-compose
-docker[ssh]==6.0.0
+docker[ssh]==6.0.1
     # via docker-compose
 docker-compose==1.29.2
     # via -r requirements/dockercompose.in
@@ -40,11 +40,11 @@ packaging==21.3
     # via
     #   build
     #   docker
-paramiko==2.11.0
+paramiko==2.12.0
     # via docker
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/dockercompose.in
 pycparser==2.21
     # via cffi
@@ -52,7 +52,7 @@ pynacl==1.5.0
     # via paramiko
 pyparsing==3.0.9
     # via packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via jsonschema
 python-dotenv==0.21.0
     # via docker-compose
@@ -82,13 +82,13 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via
     #   jsonschema
     #   pip-tools

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -6,7 +6,7 @@
 #
 black==22.10.0
     # via -r requirements/format.in
-build==0.8.0
+build==0.9.0
     # via pip-tools
 click==8.1.3
     # via
@@ -18,13 +18,13 @@ mypy-extensions==0.4.3
     # via black
 packaging==21.3
     # via build
-pathspec==0.10.1
+pathspec==0.10.2
     # via black
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/format.in
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via black
 pyparsing==3.0.9
     # via packaging
@@ -35,11 +35,11 @@ tomli==2.0.1
     #   pep517
 typing-extensions==4.4.0
     # via black
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via pip-tools

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -6,21 +6,22 @@
 #
 attrs==22.1.0
     # via pytest
-build==0.8.0
+build==0.9.0
     # via pip-tools
 certifi==2022.9.24
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
+    #   sentry-sdk
 click==8.1.3
     # via pip-tools
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.0.4
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/functests.in
-faker==15.1.1
+faker==15.3.2
     # via factory-boy
-greenlet==1.1.3.post0
+greenlet==2.0.1
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
@@ -28,7 +29,7 @@ h-matchers==1.2.15
     # via -r requirements/functests.in
 httpretty==1.1.4
     # via -r requirements/functests.in
-hubspot-api-client==6.1.0
+hubspot-api-client==7.0.0
     # via -r requirements/prod.txt
 importlib-resources==5.10.0
     # via -r requirements/prod.txt
@@ -48,7 +49,7 @@ packaging==21.3
     #   pytest
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/functests.in
 pluggy==1.0.0
     # via pytest
@@ -63,12 +64,14 @@ python-dateutil==2.8.2
     #   -r requirements/prod.txt
     #   faker
     #   hubspot-api-client
+sentry-sdk==1.11.0
+    # via -r requirements/prod.txt
 six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
     #   python-dateutil
-sqlalchemy==1.4.42
+sqlalchemy==1.4.44
     # via -r requirements/prod.txt
 sqlparse==0.4.3
     # via -r requirements/prod.txt
@@ -83,7 +86,8 @@ urllib3==1.26.12
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
-wheel==0.37.1
+    #   sentry-sdk
+wheel==0.38.4
     # via pip-tools
 zipp==3.10.0
     # via
@@ -91,7 +95,7 @@ zipp==3.10.0
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via pip-tools

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -11,7 +11,7 @@ attrs==22.1.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
-build==0.8.0
+build==0.9.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -21,6 +21,7 @@ certifi==2022.9.24
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   hubspot-api-client
+    #   sentry-sdk
 click==8.1.3
     # via
     #   -r requirements/functests.txt
@@ -30,7 +31,7 @@ coverage[toml]==6.5.0
     # via -r requirements/tests.txt
 dill==0.3.6
     # via pylint
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.0.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -39,14 +40,14 @@ factory-boy==3.2.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-faker==15.1.1
+faker==15.3.2
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   factory-boy
 freezegun==1.2.2
     # via -r requirements/tests.txt
-greenlet==1.1.3.post0
+greenlet==2.0.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -59,7 +60,7 @@ httpretty==1.1.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-hubspot-api-client==6.1.0
+hubspot-api-client==7.0.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -78,7 +79,7 @@ jinja2==3.1.2
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
     # via astroid
 markupsafe==2.1.1
     # via
@@ -102,12 +103,12 @@ pep517==0.13.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/lint.in
     #   -r requirements/tests.txt
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via pylint
 pluggy==1.0.0
     # via
@@ -140,6 +141,10 @@ python-dateutil==2.8.2
     #   faker
     #   freezegun
     #   hubspot-api-client
+sentry-sdk==1.11.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
 six==1.16.0
     # via
     #   -r requirements/functests.txt
@@ -148,7 +153,7 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlalchemy==1.4.42
+sqlalchemy==1.4.44
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -171,7 +176,7 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
-tomlkit==0.11.5
+tomlkit==0.11.6
     # via pylint
 typing-extensions==4.4.0
     # via
@@ -182,7 +187,8 @@ urllib3==1.26.12
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   hubspot-api-client
-wheel==0.37.1
+    #   sentry-sdk
+wheel==0.38.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -196,12 +202,12 @@ zipp==3.10.0
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -1,9 +1,11 @@
+# From .cookiecutter/includes/requirements/prod.in:
 newrelic
 
 hubspot-api-client
 importlib_resources
 jinja2
 psycopg2
+sentry-sdk
 SQLAlchemy
 sqlparse
 tabulate

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,10 +5,12 @@
 #    pip-compile --allow-unsafe requirements/prod.in
 #
 certifi==2022.9.24
-    # via hubspot-api-client
-greenlet==1.1.3.post0
+    # via
+    #   hubspot-api-client
+    #   sentry-sdk
+greenlet==2.0.1
     # via sqlalchemy
-hubspot-api-client==6.1.0
+hubspot-api-client==7.0.0
     # via -r requirements/prod.in
 importlib-resources==5.10.0
     # via -r requirements/prod.in
@@ -22,17 +24,21 @@ psycopg2==2.9.5
     # via -r requirements/prod.in
 python-dateutil==2.8.2
     # via hubspot-api-client
+sentry-sdk==1.11.0
+    # via -r requirements/prod.in
 six==1.16.0
     # via
     #   hubspot-api-client
     #   python-dateutil
-sqlalchemy==1.4.42
+sqlalchemy==1.4.44
     # via -r requirements/prod.in
 sqlparse==0.4.3
     # via -r requirements/prod.in
 tabulate==0.9.0
     # via -r requirements/prod.in
 urllib3==1.26.12
-    # via hubspot-api-client
+    # via
+    #   hubspot-api-client
+    #   sentry-sdk
 zipp==3.10.0
     # via importlib-resources

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -8,7 +8,7 @@ arrow==1.2.3
     # via jinja2-time
 binaryornot==0.4.4
     # via cookiecutter
-build==0.8.0
+build==0.9.0
     # via pip-tools
 certifi==2022.9.24
     # via requests
@@ -36,7 +36,7 @@ packaging==21.3
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/template.in
 pyparsing==3.0.9
     # via packaging
@@ -58,11 +58,11 @@ tomli==2.0.1
     #   pep517
 urllib3==1.26.12
     # via requests
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via pip-tools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,25 +6,26 @@
 #
 attrs==22.1.0
     # via pytest
-build==0.8.0
+build==0.9.0
     # via pip-tools
 certifi==2022.9.24
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
+    #   sentry-sdk
 click==8.1.3
     # via pip-tools
 coverage[toml]==6.5.0
     # via -r requirements/tests.in
-exceptiongroup==1.0.0rc9
+exceptiongroup==1.0.4
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/tests.in
-faker==15.1.1
+faker==15.3.2
     # via factory-boy
 freezegun==1.2.2
     # via -r requirements/tests.in
-greenlet==1.1.3.post0
+greenlet==2.0.1
     # via
     #   -r requirements/prod.txt
     #   sqlalchemy
@@ -32,7 +33,7 @@ h-matchers==1.2.15
     # via -r requirements/tests.in
 httpretty==1.1.4
     # via -r requirements/tests.in
-hubspot-api-client==6.1.0
+hubspot-api-client==7.0.0
     # via -r requirements/prod.txt
 importlib-resources==5.10.0
     # via -r requirements/prod.txt
@@ -52,7 +53,7 @@ packaging==21.3
     #   pytest
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/tests.in
 pluggy==1.0.0
     # via pytest
@@ -68,12 +69,14 @@ python-dateutil==2.8.2
     #   faker
     #   freezegun
     #   hubspot-api-client
+sentry-sdk==1.11.0
+    # via -r requirements/prod.txt
 six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
     #   python-dateutil
-sqlalchemy==1.4.42
+sqlalchemy==1.4.44
     # via -r requirements/prod.txt
 sqlparse==0.4.3
     # via -r requirements/prod.txt
@@ -89,7 +92,8 @@ urllib3==1.26.12
     # via
     #   -r requirements/prod.txt
     #   hubspot-api-client
-wheel==0.37.1
+    #   sentry-sdk
+wheel==0.38.4
     # via pip-tools
 zipp==3.10.0
     # via
@@ -97,7 +101,7 @@ zipp==3.10.0
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.3
+pip==22.3.1
     # via pip-tools
-setuptools==65.5.0
+setuptools==65.5.1
     # via pip-tools

--- a/tests/unit/report/sentry_test.py
+++ b/tests/unit/report/sentry_test.py
@@ -1,0 +1,29 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from report.sentry import load_sentry
+
+
+class TestLoadSentry:
+    def test_it(self, os, sentry_sdk):
+        os.environ = {"SENTRY_DSN": sentinel.sentry_dsn}
+
+        load_sentry()
+
+        sentry_sdk.init.assert_called_once_with(dsn=sentinel.sentry_dsn)
+
+    def test_it_with_no_sentry_dsn(self, os, sentry_sdk):
+        os.environ = {}
+
+        load_sentry()
+
+        sentry_sdk.init.assert_not_called()
+
+    @pytest.fixture
+    def os(self, patch):
+        return patch("report.sentry.os")
+
+    @pytest.fixture
+    def sentry_sdk(self, patch):
+        return patch("report.sentry.sentry_sdk")

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     # Make `import report` work in `make shell`.
     dev: PYTHONPATH = .
+    # From .cookiecutter/includes/tox/setenv:
     MB_DB_USER = {env:MB_DB_USER:postgres}
     # As it's Postgres itself that will be contacting these DBs, this will
     # happen inside docker, so we use docker names here
@@ -21,12 +22,15 @@ setenv =
     H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
     LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
     LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
+    dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
 passenv =
     HOME
     PYTEST_ADDOPTS
     GUNICORN_CERTFILE
     GUNICORN_KEYFILE
+    # From .cookiecutter/includes/tox/passenv:
     HUBSPOT_API_KEY
+    SENTRY_DSN
     TEST_DATABASE_URL
 deps =
     pip-tools


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/48

## Testing notes

 * Get the DSN from: https://sentry.io/settings/hypothesis/projects/report/keys/
 * Add 1/0 after the sentry init in `bin/run_sql_task.py`
 * Run: `SENTRY_DSN=... tox -e dev --run-command 'python bin/run_sql_task.py'`
 * You should see an entry in: https://sentry.io/organizations/hypothesis/projects/report/?project=4504163606790144