### PR TITLE
Add a dry-run capability to the script runner

### DIFF
--- a/bin/run_sql_task.py
+++ b/bin/run_sql_task.py
@@ -29,6 +29,13 @@ parser.add_argument(
     const=True,
     help="Skip Python executables",
 )
+parser.add_argument(
+    "--dry-run",
+    action="store_const",
+    default=False,
+    const=True,
+    help="Run through the task without executing anything for real",
+)
 
 
 def _get_dsn(env_var_name):
@@ -63,7 +70,10 @@ def main():
                     print(f"Skipping: {script}")
                     continue
 
-                for step in script.execute(connection):
+                for step in script.execute(connection, dry_run=args.dry_run):
+                    if args.dry_run:
+                        print("Dry run!")
+
                     print(step.dump(indent="    ") + "\n")
 
 

--- a/report/sql_tasks/python_script.py
+++ b/report/sql_tasks/python_script.py
@@ -45,12 +45,13 @@ class PythonScript:
                 f"Expected to find `main()` function in {self.path}"
             )
 
-    def execute(self, connection):
+    def execute(self, connection, dry_run=False):
         """Execute the python script."""
 
         with self.timing.time_it():
             # pylint: disable=no-member
-            self.result = self.module.main(connection=connection)
+            if not dry_run:
+                self.result = self.module.main(connection=connection)
 
         yield self
 

--- a/report/sql_tasks/sql_query.py
+++ b/report/sql_tasks/sql_query.py
@@ -29,12 +29,15 @@ class SQLQuery:
     timing: Timer = field(default_factory=Timer)
     """Timer for query execution."""
 
-    def execute(self, connection: Connection, parameters=None):
+    def execute(self, connection: Connection, dry_run=False, parameters=None):
         """Execute this query in the given session."""
 
         with self.timing.time_it():
             if not parameters:
                 parameters = {}
+
+            if dry_run:
+                return
 
             cursor = connection.execute(sa.text(self.text), **parameters)
             if cursor.returns_rows:

--- a/report/sql_tasks/sql_script.py
+++ b/report/sql_tasks/sql_script.py
@@ -31,10 +31,12 @@ class SQLScript:
         if not self.queries:
             self.queries = self._parse()
 
-    def execute(self, connection):
+    def execute(self, connection, dry_run=False):
+        """Execute this script with the given connection."""
+
         with self.timing.time_it():
             for query in self.queries:
-                query.execute(connection)
+                query.execute(connection, dry_run=dry_run)
                 yield query
 
         yield self

--- a/tests/unit/report/sql_tasks/python_script_test.py
+++ b/tests/unit/report/sql_tasks/python_script_test.py
@@ -26,6 +26,12 @@ class TestPythonScript:
         assert items == [python_script]
         assert python_script.result == "script_run"
 
+    def test_execute_with_dry_run(self, python_script):
+        items = list(python_script.execute(sentinel.connection, dry_run=True))
+
+        assert items == [python_script]
+        assert python_script.result is None
+
     @pytest.fixture
     def empty_script(self, tmp_path):
         empty_script = tmp_path / "script.py"

--- a/tests/unit/report/sql_tasks/sql_query_test.py
+++ b/tests/unit/report/sql_tasks/sql_query_test.py
@@ -20,6 +20,14 @@ class TestSQLQuery:
 
         assert query.rows == [(12,)]
 
+    def test_execute_with_dry_run(self, connection):
+        query = SQLQuery(0, "THIS IS NOT SQL")
+        self.assert_query_null_pre_execute(query)
+
+        query.execute(connection, dry_run=True)
+
+        assert query.timing.start_time is not None
+
     def test_execute_with_a_query_returning_no_rows(self, query_no_rows, connection):
         self.assert_query_null_pre_execute(query_no_rows)
 

--- a/tests/unit/report/sql_tasks/sql_script_test.py
+++ b/tests/unit/report/sql_tasks/sql_script_test.py
@@ -14,7 +14,9 @@ class TestSQLScript:
         query = create_autospec(SQLQuery, spec_set=True, instance=True)
         script = SQLScript(path="/long/path", template_vars={}, queries=[query])
 
-        items = list(script.execute(sentinel.connection))
+        items = list(script.execute(sentinel.connection, dry_run=sentinel.dry_run))
 
         assert items == [query, script]
-        query.execute.assert_called_once_with(sentinel.connection)
+        query.execute.assert_called_once_with(
+            sentinel.connection, dry_run=sentinel.dry_run
+        )


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/47

This adds `--dry-run` to the task runner.

## Testing notes

 * tox -e dev --run-command 'python bin/run_sql_task.py --task hello_world --dry-run'