### PR TITLE
Add back `DATABASE_DSN` for local testing using tox

### DIFF
--- a/.cookiecutter/includes/tox/passenv
+++ b/.cookiecutter/includes/tox/passenv
@@ -1,4 +1,3 @@
 # From .cookiecutter/includes/tox/passenv:
 HUBSPOT_API_KEY
-SENTRY_DSN
 TEST_DATABASE_URL

--- a/.cookiecutter/includes/tox/setenv
+++ b/.cookiecutter/includes/tox/setenv
@@ -6,4 +6,6 @@ H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://postgres:postgres@h_post
 H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
 LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
 LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
+# Used when testing tasks via `tox`:
+dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5436/postgres}
 dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ test: python
 
 .PHONY: coverage
 $(call help,make coverage,"run the tests and print the coverage report")
-coverage: python	@pyenv exec tox --parallel -qe 'tests,py{}-tests,coverage'
+coverage: python
+	@pyenv exec tox -qe 'tests,coverage'
+
 .PHONY: functests
 $(call help,make functests,"run the functional tests in Python 3.8")
 functests: python

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,14 @@ setenv =
     H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
     LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
     LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
+    # Used when testing tasks via `tox`:
+    dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5436/postgres}
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
 passenv =
     HOME
     PYTEST_ADDOPTS
+    dev: DEBUG
+    dev: SENTRY_DSN
     GUNICORN_CERTFILE
     GUNICORN_KEYFILE
     # From .cookiecutter/includes/tox/passenv:


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/69

Discovered in:

 * https://github.com/hypothesis/report/pull/72

## Testing notes

 * `tox -e dev --run-command 'python bin/run_sql_task.py --task hello_world --dry-run'`
 * Doesn't crash!