### PR TITLE
Re-order organization activity columns into like types and make payable boolean

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/02_organization_activity/01_create_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/02_organization_activity/01_create_view.sql
@@ -29,8 +29,18 @@ CREATE MATERIALIZED VIEW organization_activity AS (
         )
 
     SELECT
-        raw_organization_activity.*,
-        COALESCE(paying, FALSE) AS paying
+        -- Time based elements
+        raw_organization_activity.timescale,
+        raw_organization_activity.calendar_date,
+        raw_organization_activity.period,
+        -- Facets
+        raw_organization_activity.role,
+        COALESCE(paying, FALSE)::BOOLEAN AS paying,
+        raw_organization_activity.organization_id,
+        -- Metrics
+        raw_organization_activity.annotation_count,
+        raw_organization_activity.active,
+        raw_organization_activity.billable
     FROM raw_organization_activity
     LEFT OUTER JOIN LATERAL (
         SELECT


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/50

This is to try and make the table nicer when looking at it by default. The original table was designed, but over time we've just tacked columns on the end.

The addition of a boolean type will hopefully hint Metabase to provide a nice drop down.