### PR TITLE
Fix the docker network name and add `newrelic-admin`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --virtual build-deps \
 FROM metabase/metabase:v0.44.5
 
 # Copy the python binaries and libraries from the python image
-# The metabase image is based on a newer alpine and the python package there 
+# The metabase image is based on a newer alpine and the python package there
 # won't point to the exact version we need.
 COPY --from=python /usr/local/bin/python3 /usr/local/bin/python3
 COPY --from=python /usr/local/bin/python3.8 /usr/local/bin/python3.8
@@ -25,6 +25,8 @@ COPY --from=python /usr/local/lib/python3.8 /usr/local/lib/python3.8
 COPY --from=python /usr/local/lib/libpython3.8.so.1.0 /usr/local/lib/libpython3.8.so.1.0
 COPY --from=python /usr/local/lib/libpython3.so /usr/local/lib/libpython3.so
 
+# Make sure various scripts we use from Python packages are available
+COPY --from=python /usr/local/bin/newrelic-admin /usr/local/bin/newrelic-admin
 
 # We need to install some package that are not present in the metabase image
 RUN apk add libpq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - 5435:5432
     networks:
-      - report
+      - default
 
   metabase:
     build:
@@ -30,18 +30,18 @@ services:
       - metabase-postgres
       - postgres
     networks:
-      - report
+      - default
 
   postgres:
     image: postgres:11.5-alpine
     ports:
       - 5436:5432
     networks:
-      - report
+      - default
       - dbs
 
 networks:
-  report:
+  default:
     external: false
   dbs:
     external: true


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/48

I think the template expects a docker network name of `<slug>_default` in the `make docker-run` command. 

We had set the name to `report` in the docker compose setup. As this was set as a private network, I think `dockercompose` prefixes it with `report_` so we had `report_report` as our network and needed `report_default`. By setting it to `default` we should get the correct prefix and work.

This also copies the `newrelic-agent` command we need.

## Testing notes

 * `make services`
 * `make docker`
 * `make docker-run`

This should now work, whereas on `main` the last step will fail with a message about missing networks.

To test the `newrelic-admin`:

 * `docker ps`
 * Note the id of the running image
 * `docker exec -it <container_id> sh`
 * `newrelic-agent`  - Should work on the command line