### PR TITLE
Fix the argument order for name creation and dedupe the strings

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/01_organization/01_create_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/01_organization/01_create_view.sql
@@ -29,7 +29,7 @@ CREATE MATERIALIZED VIEW organizations AS (
         hubspot_names AS (
             SELECT
                 lms_organization_id,
-                STRING_AGG(' / ', name) as hubspot_name
+                STRING_AGG(DISTINCT(name), ' / ') as hubspot_name
             FROM hubspot.companies
             WHERE lms_organization_id IS NOT NULL
             GROUP BY lms_organization_id


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/51

The aggregation arguments were in the wrong order... As a bonus this also dedupes names