### PR TITLE
Fix the definition of the index to match the new columns

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/02_organization_activity/02_initial_fill.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/02_organization_activity/02_initial_fill.sql
@@ -1,5 +1,5 @@
 DROP INDEX IF EXISTS organization_activity_region_timescale_created_org_id_idx;
-DROP INDEX IF EXISTS organization_activity_calendar_date_idx;
+DROP INDEX IF EXISTS organization_activity_start_date_end_date_idx;
 
 REFRESH MATERIALIZED VIEW organization_activity;
 
@@ -7,4 +7,4 @@ ANALYSE organization_activity;
 
 -- A unique index is mandatory for concurrent updates used in the refresh
 CREATE UNIQUE INDEX organization_activity_region_timescale_created_org_id_idx ON organization_activity (timescale, period, role, organization_id);
-CREATE INDEX organization_activity_calendar_date_idx ON organization_activity (calendar_date);
+CREATE INDEX organization_activity_start_date_end_date_idx ON organization_activity (start_date, end_date);


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/50

In the previous PR I changed the columns but didn't change the indexes based on them. I could swear I've done this, but I must not have committed it? This might be a good indicator of what happens when you try to work on too many PRs at once.

This is currently breaking the report update.