### PR TITLE
Fix the join so we don't lose organizations with no name

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/01_organization/01_create_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/01_organization/01_create_view.sql
@@ -39,6 +39,6 @@ CREATE MATERIALIZED VIEW organizations AS (
         raw_organizations.*,
         hubspot_names.hubspot_name
     FROM raw_organizations
-    JOIN hubspot_names ON
+    LEFT OUTER JOIN hubspot_names ON
         raw_organizations.public_id = hubspot_names.lms_organization_id
 ) WITH NO DATA;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/51

This was removing orgs where there was no corresponding name in Hubspot