### PR TITLE
Add back minimal amounts of the cookicutter to get `make dev` working

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -4,7 +4,7 @@
   "directory": "pyapp",
   "ignore": [
       "bin/logger",
-      "conf/supervisord*.conf",
+      "conf/supervisord.conf",
       "report/__main__.py",
       "report/app.py",
       "report/core.py",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
   workflow_dispatch:
+  workflow_call:
 jobs:
   Format:
     runs-on: ubuntu-latest

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -1,0 +1,28 @@
+[supervisord]
+nodaemon=true
+silent=true
+
+[program:app]
+command=python3 -m report
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal=KILL
+stopasgroup=true
+
+[eventlistener:logger]
+command=bin/logger --dev
+buffer_size=100
+events=PROCESS_LOG
+stderr_logfile=/dev/fd/1
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/null
+
+[unix_http_server]
+file = .supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix://.supervisor.sock
+prompt = report


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/84

This doesn't do anything useful once it's running, but it does create the dev tox environment without spitting out any errors which might confuse people.

Technically the erroring version would create the environment too, but it's likely to trigger repeated investigations to see what's wrong by people so this seems tidier.