### PR TITLE
Switch to using a representative user for permissions

### DIFF
--- a/.cookiecutter/includes/tox/setenv
+++ b/.cookiecutter/includes/tox/setenv
@@ -2,10 +2,10 @@
 MB_DB_USER = {env:MB_DB_USER:postgres}
 # As it's Postgres itself that will be contacting these DBs, this will
 # happen inside docker, so we use docker names here
-H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
-H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
-LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
-LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
+H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://report-fdw:password@h_postgres_1:5432/postgres}
+H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://report-fdw:password@h_postgres_1:5432/postgres}
+LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://report-fdw:password@lms_postgres_1:5432/postgres}
+LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://report-fdw:password@lms_postgres_1:5432/postgres}
 # Used when testing tasks via `tox`:
 dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5436/postgres}
 dev: NEW_RELIC_APP_NAME = {env: NEW_RELIC_APP_NAME:report}

--- a/report/sql_tasks/tasks/report/create_from_scratch/README.md
+++ b/report/sql_tasks/tasks/report/create_from_scratch/README.md
@@ -1,0 +1,9 @@
+Create from scratch
+-------------------
+
+This task will create the reporting environment from scratch. This is required
+if tables, views etc. are redefined.
+
+This is a **dangerous** task:
+
+ * It will disrupt reporting as it's run

--- a/report/sql_tasks/tasks/report/refresh/README.md
+++ b/report/sql_tasks/tasks/report/refresh/README.md
@@ -1,0 +1,10 @@
+Refresh
+-------
+
+This is the refresh task which will update numbers since the last time it was
+run.
+
+This is a **safe** task:
+
+ * It should be quick to run
+ * It should not lock any tables it is updating

--- a/tox.ini
+++ b/tox.ini
@@ -18,10 +18,10 @@ setenv =
     MB_DB_USER = {env:MB_DB_USER:postgres}
     # As it's Postgres itself that will be contacting these DBs, this will
     # happen inside docker, so we use docker names here
-    H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
-    H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://postgres:postgres@h_postgres_1:5432/postgres}
-    LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
-    LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://postgres:postgres@lms_postgres_1:5432/postgres}
+    H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://report-fdw:password@h_postgres_1:5432/postgres}
+    H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://report-fdw:password@h_postgres_1:5432/postgres}
+    LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://report-fdw:password@lms_postgres_1:5432/postgres}
+    LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://report-fdw:password@lms_postgres_1:5432/postgres}
     # Used when testing tasks via `tox`:
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:5436/postgres}
     dev: NEW_RELIC_APP_NAME = {env: NEW_RELIC_APP_NAME:report}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/49

Requires:

 * https://github.com/hypothesis/lms/pull/4665
 * https://github.com/hypothesis/h/pull/7713

## Testing notes

 * Make sure you have run the tests in: https://github.com/hypothesis/lms/pull/4665
 * `make services`
 * `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch"`

Check permissions matter:

 * Edit: `lms/sql_tasks/tasks/report/create_from_scratch/05_grant_permissions/01_grant_schema.jinja2.sql`
 * Comment out some permissions, make sure not to comment out the last SQL line
 * In LMS run: `tox -e dev --run-command "python bin/run_sql_task.py --config-file conf/development.ini --task report/create_from_scratch"`
 * In Report run:  `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch"`
 * It should fail with permissions errors