### PR TITLE
Add `make sql` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ $(call help,make shell,"launch a Python shell in this project's virtualenv")
 shell: python
 	@pyenv exec tox -qe dev --run-command 'ipython'
 
+.PHONY: sql
+$(call help,make sql,"Connect to the dev database with a psql shell")
+sql: python
+	@tox -qe dockercompose -- exec postgres psql --pset expanded=auto -U postgres
+
 .PHONY: lint
 $(call help,make lint,"lint the code and print any warnings")
 lint: python


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/84
 
Uses:

 * https://github.com/hypothesis/cookiecutters/pull/96

You can try replaying the cookiecutter with `make template checkout=add-make-sql`

## Testing notes

 * `make services`
 * `make sql`
 * You should be able to execute queries like `SELECT * FROM organizations;`