### PR TITLE
Pass through the launches metric for organization activity

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/02_organization_activity/01_create_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/02_organization_activity/01_create_view.sql
@@ -12,7 +12,8 @@ CREATE MATERIALIZED VIEW organization_activity AS (
                 CONCAT('us-', organization_id) AS organization_id,
                 annotation_count,
                 active,
-                billable
+                billable,
+                launch_count
             FROM lms_us.organization_activity
 
             UNION ALL
@@ -26,7 +27,8 @@ CREATE MATERIALIZED VIEW organization_activity AS (
                 CONCAT('ca-', organization_id) AS organization_id,
                 annotation_count,
                 active,
-                billable
+                billable,
+                launch_count
             FROM lms_ca.organization_activity
         )
 
@@ -43,7 +45,8 @@ CREATE MATERIALIZED VIEW organization_activity AS (
         -- Metrics
         raw_organization_activity.annotation_count,
         raw_organization_activity.active,
-        raw_organization_activity.billable
+        raw_organization_activity.billable,
+        raw_organization_activity.launch_count
     FROM raw_organization_activity
     LEFT OUTER JOIN LATERAL (
         SELECT


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/92

Requires:

 * https://github.com/hypothesis/lms/pull/4676

## Testing notes

 * In LMS: `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch -c conf/development.ini"`
 * In Report: `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch --no-python"`
 *  `make sql`
 * `\d+ organization_activity`
 * You should see the new columns