### PR TITLE
Aggregate and pass through user counts in authority activity from H

### DIFF
--- a/report/sql_tasks/tasks/report/create_from_scratch/00_schema/03_create_fdw_schema_h.jinja2.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/00_schema/03_create_fdw_schema_h.jinja2.sql
@@ -1,7 +1,19 @@
+-- Create types required for imports
+
+DROP TYPE IF EXISTS report.timescale CASCADE;
+
+CREATE TYPE report.timescale AS ENUM (
+    'week', 'month', 'semester', 'academic_year', 'year', 'all_time'
+);
+
 {% macro import_h(server_name, schema_name) %}
     DROP SCHEMA IF EXISTS {{schema_name}} CASCADE;
 
     CREATE SCHEMA {{schema_name}} AUTHORIZATION "{{db_user}}";
+
+    IMPORT FOREIGN SCHEMA "report" LIMIT TO (
+        authority_activity
+    ) FROM SERVER "{{server_name}}" INTO {{schema_name}};
 {% endmacro %}
 
 {{ import_h("h_us_server", "h_us") }}

--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/03_authority_activity/01_create_view.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/03_authority_activity/01_create_view.sql
@@ -1,0 +1,19 @@
+DROP MATERIALIZED VIEW IF EXISTS authority_activity CASCADE;
+
+CREATE MATERIALIZED VIEW authority_activity AS (
+    SELECT
+        timescale, start_date, end_date, period,
+        'us' AS region,
+        authority_id,
+        annotating_users, registering_users, total_users
+    FROM h_us.authority_activity
+
+    UNION ALL
+
+    SELECT
+        timescale, start_date, end_date, period,
+        'ca' AS region,
+        authority_id,
+        annotating_users, registering_users, total_users
+    FROM h_ca.authority_activity
+) WITH NO DATA;

--- a/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/03_authority_activity/02_initial_fill.sql
+++ b/report/sql_tasks/tasks/report/create_from_scratch/03_public/01_materialized_views/03_authority_activity/02_initial_fill.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS authority_activity_timescale_period_authority_id_region_idx;
+DROP INDEX IF EXISTS authority_activity_start_date_end_date_idx;
+
+REFRESH MATERIALIZED VIEW authority_activity;
+
+ANALYSE authority_activity;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX authority_activity_timescale_period_authority_id_region_idx ON authority_activity (timescale, period, authority_id, region);
+CREATE INDEX authority_activity_start_date_end_date_idx ON authority_activity (start_date, end_date);

--- a/report/sql_tasks/tasks/report/refresh/02_public/01_materialized_views_refresh.sql
+++ b/report/sql_tasks/tasks/report/refresh/02_public/01_materialized_views_refresh.sql
@@ -3,3 +3,6 @@ ANALYSE organizations;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY organization_activity;
 ANALYSE organization_activity;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY authority_activity;
+ANALYSE authority_activity;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/90

Requires:

 * https://github.com/hypothesis/h/pull/7717

## Testing notes

 * In H: `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch --config conf/development-app.ini"`
 * In Report: `tox -e dev --run-command "python bin/run_sql_task.py --task report/create_from_scratch --no-python"`
 * `make sql`
 * `\d+ authority_activity`