### PR TITLE
Fix the name of the authorities view in the refresh script

### DIFF
--- a/report/data_tasks/report/refresh/02_public/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/02_public/01_materialized_views_refresh.sql
@@ -4,8 +4,8 @@ ANALYSE organizations;
 REFRESH MATERIALIZED VIEW CONCURRENTLY organization_activity;
 ANALYSE organization_activity;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY authority;
-ANALYSE authority;
+REFRESH MATERIALIZED VIEW CONCURRENTLY authorities;
+ANALYSE authorities;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY authority_activity;
 ANALYSE authority_activity;


### PR DESCRIPTION
Caused during:

 * https://github.com/hypothesis/report/issues/90

It's just a typo. I've chosen plurals for the report views to make it harder to accidentally clash with the real names as we generally use singular in the rest of the code. It does however catch me out every so often.