### PR TITLE
Apply the cookiecutter to `[re]deploy.yml`

### DIFF
--- a/.cookiecutter/includes/.github/workflows/environments.json
+++ b/.cookiecutter/includes/.github/workflows/environments.json
@@ -1,0 +1,17 @@
+{
+  "qa": {
+    "github_environment_name": "QA",
+    "github_environment_url": "https://report-qa.hypothes.is/",
+    "aws_region": "us-west-1",
+    "elasticbeanstalk_application": "report",
+    "elasticbeanstalk_environment": "qa"
+  },
+  "production": {
+    "needs": ["qa"],
+    "github_environment_name": "Production",
+    "github_environment_url": "https://report.hypothes.is/",
+    "aws_region": "us-west-1",
+    "elasticbeanstalk_application": "report",
+    "elasticbeanstalk_environment": "prod"
+  }
+}

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,46 +1,38 @@
-name: Deploy
+name: Redeploy
 concurrency:
   group: deploy
   cancel-in-progress: true
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+    inputs:
+      qa:
+        type: boolean
+        description: Redeploy QA
+      production:
+        type: boolean
+        description: Redeploy Production
 jobs:
-  ci:
-    name: CI
-    uses: ./.github/workflows/ci.yml
-  docker_hub:
-    name: Docker Hub
-    needs: [ci]
-    uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
-    with:
-      Application: ${{ github.event.repository.name }}
-    secrets: inherit
   qa:
     name: QA
-    needs: [docker_hub]
+    if: inputs.qa
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      operation: deploy
+      operation: redeploy
       github_environment_name: QA
       github_environment_url: https://report-qa.hypothes.is/
       aws_region: us-west-1
       elasticbeanstalk_application: report
       elasticbeanstalk_environment: qa
-      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit
   production:
     name: Production
-    needs: [docker_hub, qa]
+    if: inputs.production
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      operation: deploy
+      operation: redeploy
       github_environment_name: Production
       github_environment_url: https://report.hypothes.is/
       aws_region: us-west-1
       elasticbeanstalk_application: report
       elasticbeanstalk_environment: prod
-      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit


### PR DESCRIPTION
Apply [the cookiecutter](https://github.com/hypothesis/cookiecutters) to the GitHub Actions workflows `deploy.yml` and `redeploy.yml`.

This makes only formatting changes to `deploy.yml`, no functional changes.

This adds `redeploy.yml` which provides an easy way to redeploy the current version of the app from the repo's GitHub Actions tab.