### PR TITLE
Pin to tox<4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             format-${{ runner.os }}-tox-
       - name: Create test database
         run: psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE report_test'
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
             lint-${{ runner.os }}-tox-
       - name: Create test database
         run: psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE report_test'
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
             tests-${{ runner.os }}-tox-
       - name: Create test database
         run: psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE report_test'
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -116,7 +116,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -142,5 +142,5 @@ jobs:
             functests-${{ runner.os }}-tox-
       - name: Create test database
         run: psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE report_test'
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e functests

--- a/bin/make_python
+++ b/bin/make_python
@@ -12,7 +12,7 @@ for python_version in 3.8.12; do
     bin_dir=$pyenv_root/versions/$python_version/bin
     if [ ! -f "$bin_dir"/tox ]; then
         pyenv install --skip-existing "$python_version"
-        "$bin_dir"/pip install --disable-pip-version-check tox
+        "$bin_dir"/pip install --disable-pip-version-check 'tox<4'
         pyenv rehash
     fi
 done

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = tests
 skipsdist = true
-minversion = 3.25.0
 requires =
+    tox>=3.25.0,<4
     tox-envfile
     tox-faster
     tox-run-command


### PR DESCRIPTION
Pin to tox<4 to avoid breakage caused by tox 4.0.0 backwards-incompatibilities.

See https://github.com/hypothesis/cookiecutter-pyapp-test/pull/6 for details.
