### PR TITLE
Update the refresh scripts to work with the new schema

### DIFF
--- a/report/data_tasks/report/refresh/02_h/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/02_h/01_materialized_views_refresh.sql
@@ -1,5 +1,5 @@
-REFRESH MATERIALIZED VIEW CONCURRENTLY authorities;
-ANALYSE authorities;
+REFRESH MATERIALIZED VIEW CONCURRENTLY h.authorities;
+ANALYSE h.authorities;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY authority_activity;
-ANALYSE authority_activity;
+REFRESH MATERIALIZED VIEW CONCURRENTLY h.authority_activity;
+ANALYSE h.authority_activity;

--- a/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
@@ -1,8 +1,8 @@
-REFRESH MATERIALIZED VIEW CONCURRENTLY organizations;
-ANALYSE organizations;
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organizations;
+ANALYSE lms.organizations;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY organization_activity;
-ANALYSE organization_activity;
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_activity;
+ANALYSE lms.organization_activity;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY lms_events;
-ANALYSE lms_events;
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.events;
+ANALYSE lms.events;


### PR DESCRIPTION
When migrating the views to their own schema I missed the update scripts. This should fix the refresh.