### PR TITLE
Pass through groups and counts to Report

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -28,7 +28,11 @@ CREATE TYPE report.academic_timescale AS ENUM (
 
     IMPORT FOREIGN SCHEMA "report" LIMIT TO (
         organization_activity,
-        events
+        events,
+        groups,
+        group_map,
+        group_bubbled_counts,
+        group_bubbled_activity
     ) FROM SERVER "{{server_name}}" INTO {{schema_name}};
 {% endmacro %}
 

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_groups/01_groups/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_groups/01_groups/01_create_view.sql
@@ -1,0 +1,33 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.groups CASCADE;
+
+CREATE MATERIALIZED VIEW lms.groups AS (
+    SELECT
+        CONCAT('us-', id) AS id,
+        'us' AS region,
+        CASE
+            WHEN parent_id IS NULL THEN NULL
+            ELSE CONCAT('us-', parent_id)
+        END AS parent_id,
+        authority_provided_id, name, group_type, created,
+        -- From bubbled counts
+        teacher_count, user_count, assignment_count, document_count
+    FROM lms_us.groups
+    JOIN lms_us.group_bubbled_counts ON
+        group_bubbled_counts.group_id = groups.id
+
+    UNION ALL
+
+    SELECT
+        CONCAT('ca-', id) AS id,
+        'ca' AS region,
+        CASE
+            WHEN parent_id IS NULL THEN NULL
+            ELSE CONCAT('ca-', parent_id)
+        END AS parent_id,
+        authority_provided_id, name, group_type, created,
+        -- From bubbled counts
+        teacher_count, user_count, assignment_count, document_count
+    FROM lms_ca.groups
+    JOIN lms_ca.group_bubbled_counts ON
+        group_bubbled_counts.group_id = groups.id
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_groups/01_groups/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_groups/01_groups/02_initial_fill.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS lms.groups_id_idx;
+DROP INDEX IF EXISTS lms.groups_created_group_type_idx;
+
+REFRESH MATERIALIZED VIEW lms.groups;
+
+ANALYSE lms.groups;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX groups_id_idx ON lms.groups (id);
+CREATE INDEX groups_created_group_type_idx ON lms.groups (created, group_type);

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_groups/02_group_map/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_groups/02_group_map/01_create_view.sql
@@ -1,0 +1,31 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.group_map CASCADE;
+
+CREATE MATERIALIZED VIEW lms.group_map AS (
+    SELECT
+        CONCAT('us-', group_id) AS group_id,
+        CASE
+            WHEN organization_id IS NULL THEN NULL
+            ELSE CONCAT('us-', organization_id)
+        END AS organization_id,
+        CASE
+            WHEN lms_grouping_id IS NULL THEN NULL
+            ELSE CONCAT('us-', lms_grouping_id)
+        END AS lms_grouping_id
+    FROM
+        lms_us.group_map
+
+    UNION ALL
+
+    SELECT
+        CONCAT('ca-', group_id) AS group_id,
+        CASE
+            WHEN organization_id IS NULL THEN NULL
+            ELSE CONCAT('ca-', organization_id)
+        END AS organization_id,
+        CASE
+            WHEN lms_grouping_id IS NULL THEN NULL
+            ELSE CONCAT('ca-', lms_grouping_id)
+        END AS lms_grouping_id
+    FROM
+        lms_ca.group_map
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_groups/02_group_map/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_groups/02_group_map/02_initial_fill.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS lms.group_map_group_id_lms_grouping_id_idx;
+DROP INDEX IF EXISTS lms.group_map_organization_id_idx;
+
+REFRESH MATERIALIZED VIEW lms.group_map;
+
+ANALYSE lms.group_map;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX group_map_group_id_lms_grouping_id_idx ON lms.group_map (group_id, lms_grouping_id);
+CREATE INDEX group_map_organization_id_idx ON lms.group_map (organization_id);

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_groups/03_group_bubbled_activity/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_groups/03_group_bubbled_activity/01_create_view.sql
@@ -1,0 +1,23 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.group_bubbled_activity CASCADE;
+
+CREATE MATERIALIZED VIEW lms.group_bubbled_activity AS (
+    SELECT
+        created_week,
+        CONCAT('us-', group_id) as group_id,
+        annotation_count,
+        annotation_shared_count,
+        annotation_replies_count,
+        launch_count
+    FROM lms_us.group_bubbled_activity
+
+    UNION ALL
+
+    SELECT
+        created_week,
+        CONCAT('ca-', group_id) as group_id,
+        annotation_count,
+        annotation_shared_count,
+        annotation_replies_count,
+        launch_count
+    FROM lms_ca.group_bubbled_activity
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_groups/03_group_bubbled_activity/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_groups/03_group_bubbled_activity/02_initial_fill.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS lms.group_bubbled_activity_group_id_created_week_idx;
+
+REFRESH MATERIALIZED VIEW lms.group_bubbled_activity;
+
+ANALYSE lms.group_bubbled_activity;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX group_bubbled_activity_group_id_created_week_idx ON lms.group_bubbled_activity (group_id, created_week);

--- a/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
@@ -6,3 +6,12 @@ ANALYSE lms.organization_activity;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.events;
 ANALYSE lms.events;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.groups;
+ANALYSE lms.groups;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.group_map;
+ANALYSE lms.group_map;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.group_bubbled_activity;
+ANALYSE lms.group_bubbled_activity;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/119

Needs:

 * https://github.com/hypothesis/lms/pull/4764

We join the bubbled counts onto the group table here for convenience

## What the tables are for

`groups`

Displays the name, type and create date. This will be the base table we join onto.

This will also allow us to display the total number of courses required in the overview boards.

`group_map`

This will enable us to display the groups associated with an organization in their page

`group_bubbled_activity`

Used to present the main filterable table of info in the grouping overview and organization focus boards.

