### PR TITLE
Fix requirements: missing typing_extensions

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -110,6 +110,10 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.txt
     #   data-tasks
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
 traitlets==5.5.0
     # via
     #   ipython
@@ -127,6 +131,7 @@ zipp==3.10.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -17,6 +17,8 @@ click==8.1.3
     # via pip-tools
 data-tasks==0.0.2
     # via -r requirements/prod.txt
+exceptiongroup==1.1.0
+    # via pytest
 factory-boy==3.2.1
     # via -r requirements/functests.in
 faker==15.3.2
@@ -91,6 +93,11 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.txt
     #   data-tasks
+tomli==2.0.1
+    # via
+    #   build
+    #   pep517
+    #   pytest
 urllib3==1.26.12
     # via
     #   -r requirements/prod.txt
@@ -102,6 +109,7 @@ zipp==3.10.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -35,6 +35,11 @@ data-tasks==0.0.2
     #   -r requirements/tests.txt
 dill==0.3.6
     # via pylint
+exceptiongroup==1.1.0
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   pytest
 factory-boy==3.2.1
     # via
     #   -r requirements/functests.txt
@@ -176,8 +181,21 @@ tabulate==0.9.0
     #   data-tasks
 toml==0.10.2
     # via -r requirements/lint.in
+tomli==2.0.1
+    # via
+    #   -r requirements/functests.txt
+    #   -r requirements/tests.txt
+    #   build
+    #   coverage
+    #   pep517
+    #   pylint
+    #   pytest
 tomlkit==0.11.6
     # via pylint
+typing-extensions==4.4.0
+    # via
+    #   astroid
+    #   pylint
 urllib3==1.26.12
     # via
     #   -r requirements/functests.txt
@@ -196,6 +214,7 @@ zipp==3.10.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -49,4 +49,6 @@ urllib3==1.26.12
     #   hubspot-api-client
     #   sentry-sdk
 zipp==3.10.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -19,6 +19,8 @@ coverage[toml]==6.5.0
     # via -r requirements/tests.in
 data-tasks==0.0.2
     # via -r requirements/prod.txt
+exceptiongroup==1.1.0
+    # via pytest
 factory-boy==3.2.1
     # via -r requirements/tests.in
 faker==15.3.2
@@ -96,6 +98,12 @@ tabulate==0.9.0
     # via
     #   -r requirements/prod.txt
     #   data-tasks
+tomli==2.0.1
+    # via
+    #   build
+    #   coverage
+    #   pep517
+    #   pytest
 urllib3==1.26.12
     # via
     #   -r requirements/prod.txt
@@ -107,6 +115,7 @@ zipp==3.10.0
     # via
     #   -r requirements/prod.txt
     #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1


### PR DESCRIPTION
Just run `make requirements` in `main`.


We seemed to be missing a few transient dependencies 