### PR TITLE
Add trailing year metrics to the export for Hubspot

### DIFF
--- a/report/data_tasks/report/create_from_scratch/99_hubspot_write/01_company_property_update/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/99_hubspot_write/01_company_property_update/01_create_view.sql
@@ -20,7 +20,9 @@ CREATE VIEW hubspot.company_property_update AS (
                     ('lms_users_this_academic_year', 'user', 'academic_year', 0),
                     ('lms_users_last_semester', 'user', 'semester', 1),
                     ('lms_users_this_semester', 'user', 'semester', 0),
-                    ('lms_users_all_time', 'user', 'all_time', 0)
+                    ('lms_users_all_time', 'user', 'all_time', 0),
+                    ('lms_users_last_24_12_months', 'user', 'trailing_year', 1),
+                    ('lms_users_last_12_0_months', 'user', 'trailing_year', 0)
             ) AS data
         ),
 
@@ -68,7 +70,9 @@ CREATE VIEW hubspot.company_property_update AS (
         COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_this_academic_year'), 0) AS lms_users_this_academic_year,
         COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_last_semester'), 0) AS lms_users_last_semester,
         COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_this_semester'), 0) AS lms_users_this_semester,
-        COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_all_time'), 0) AS lms_users_all_time
+        COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_all_time'), 0) AS lms_users_all_time,
+        COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_last_24_12_months'), 0) AS lms_users_last_24_12_months,
+        COALESCE(MAX(count) FILTER (WHERE metric_name='lms_users_last_12_0_months'), 0) AS lms_users_last_12_0_months
     FROM values_in_rows
     JOIN lms.organizations ON
         organization_id = organizations.id


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/169

This adds some extra fields to export trailing year metrics to Hubspot. This requires some fields for us to export to before we can run this.

The fields we require for this should be in the main Hubspot now. We can add the fields ourselves to the Hubspot sandbox? I think you can achieve this by syncing it, but I can't remember how.

## Testing notes

I'm not sure there's much we can do to test this properly.  The create from scratch then needs to be run (making sure not to skip Python).