### PR TITLE
Expose tables needed to show teachers in courses

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -27,12 +27,15 @@ CREATE TYPE report.academic_timescale AS ENUM (
     ) FROM SERVER "{{server_name}}" INTO {{schema_name}};
 
     IMPORT FOREIGN SCHEMA "report" LIMIT TO (
-        organization_activity,
         events,
         groups,
         group_map,
         group_bubbled_counts,
-        group_bubbled_activity
+        group_bubbled_activity,
+        organization,
+        organization_activity,
+        organization_roles,
+        user_sensitive
     ) FROM SERVER "{{server_name}}" INTO {{schema_name}};
 {% endmacro %}
 


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/179

## What happened?

This tables were added as a part of a PR which used this to try and calculate this data ahead of time:

 * https://github.com/hypothesis/report/pull/153
 
It was then determined this wouldn't work and it would have to be done in SQL in Metabase. The PR was then reverted:

 * https://github.com/hypothesis/report/pull/157

But the work in Metabase relied on it, and the query was then broken:

 * https://report.hypothes.is/question/118-teachers-in-organization-fast-sql?public_id=us.lms.org.TARKQ36QQAGEfIowmGOuGQ

## A review of the tables needed by the SQL:

* `organization`
* `organization_roles`
* `users_sensitive`