### PR TITLE
Fix a typo in the FDW imports for `users_sensitive`

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -35,7 +35,7 @@ CREATE TYPE report.academic_timescale AS ENUM (
         organization,
         organization_activity,
         organization_roles,
-        user_sensitive
+        users_sensitive
     ) FROM SERVER "{{server_name}}" INTO {{schema_name}};
 {% endmacro %}
 

--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -29,9 +29,10 @@ CREATE TYPE report.academic_timescale AS ENUM (
     IMPORT FOREIGN SCHEMA "report" LIMIT TO (
         events,
         groups,
-        group_map,
-        group_bubbled_counts,
         group_bubbled_activity,
+        group_bubbled_counts,
+        group_map,
+        group_roles,
         organization,
         organization_activity,
         organization_roles,


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/179

Not done right in:

 * https://github.com/hypothesis/report/pull/178

It seems that importing a table which doesn't exist isn't an error? This is news to me. This is the first time we are importing tables which we don't consume our selves as a part of the report build (which would definitely fail), so this is the first time I've seen this.

This PR also adds another missing table required by:

 * https://report.hypothes.is/question/117-teachers-in-group-fast-sql?group_id=us-25514222