### PR TITLE
Sort the start and end-dates on Hubspot deals

### DIFF
--- a/report/data_tasks/report/create_from_scratch/02_hubspot_read/02_data_import/01_hubspot_import.py
+++ b/report/data_tasks/report/create_from_scratch/02_hubspot_read/02_data_import/01_hubspot_import.py
@@ -69,6 +69,7 @@ def main(connection, **kwargs):
 
     print("\tDeals...")
     deals = list(api_client.get_deals(DEAL_FIELDS))
+    _sort_deal_dates(deals)
 
     print("\tCompany deal associations...")
     company_deals = [
@@ -102,3 +103,17 @@ def main(connection, **kwargs):
         items=company_deals,
         fields=COMPANY_DEAL_FIELDS,
     )
+
+
+def _sort_deal_dates(deals):
+    """Ensure the start of a deal comes before the end.
+
+    This should be true, but as these values are entered by people there's
+    nothing really stopping them from being put in backwards, which will cause
+    Postgres conniptions
+    """
+    for deal in deals:
+        services_start, services_end = deal["services_start"], deal["services_end"]
+        if services_start and services_end:
+            deal["services_start"] = min(services_start, services_end)
+            deal["services_end"] = max(services_start, services_end)


### PR DESCRIPTION
As this is manually entered data, it's sometimes the wrong way around. This is to try prevent SQL errors where we try and create a date range using these values.

## Testing notes

 * `make devdata`
 * Start services in `h`, LMS, and Report
 * Run the create from scratch in `h`, LMS, and Report
 * It may fail in Report
 * Run 
```shell
tox -e dev --run-command "python bin/run_data_task.py -t report/create_from_scratch/02_hubspot_read"
```
 * `make sql`
```sql
SELECT * FROM hubspot.deals WHERE services_start > services_end
```
 * In main you should see 6 or so rows, in this PR none