### PR TITLE
Add missing type for report.event_type

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -7,7 +7,7 @@ CREATE TYPE report.roles AS ENUM (
 
 DROP TYPE IF EXISTS report.event_type CASCADE;
 CREATE TYPE report.event_type AS ENUM (
-    'configured_launch', 'deep_linking', 'audit'
+    'configured_launch', 'deep_linking', 'audit', 'edited_assignment'
 );
 
 DROP TYPE IF EXISTS report.academic_timescale CASCADE;


### PR DESCRIPTION
Missing `edited_assignment` to fix:

```
invalid input value for enum report.event_type: "edited_assignment"
```


See: https://github.com/hypothesis/lms/pull/5187