### PR TITLE
Metabase upgrade `0.46.1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --virtual build-deps \
   && apk del build-deps
 
 
-FROM metabase/metabase:v0.45.1
+FROM metabase/metabase:v0.46.1
 
 # Copy the python binaries and libraries from the python image
 # The metabase image is based on a newer alpine and the python package there


### PR DESCRIPTION
https://github.com/metabase/metabase/releases/tag/v0.46.1
https://www.metabase.com/releases/metabase-46

Was previously using `0.45.1`