### PR TITLE
Rolled back metabase to 0.45.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --virtual build-deps \
   && apk del build-deps
 
 
-FROM metabase/metabase:v0.46.1
+FROM metabase/metabase:v0.45.1
 
 # Copy the python binaries and libraries from the python image
 # The metabase image is based on a newer alpine and the python package there


### PR DESCRIPTION
Bugs have been identified in 0.46.1 that are considered too hard to work around so we are rolling back to 0.45.1.