### PR TITLE
Make the contact email matching case insensitive

### DIFF
--- a/report/data_tasks/report/create_from_scratch/99_hubspot_write/02_contact_property_update/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/99_hubspot_write/02_contact_property_update/01_create_view.sql
@@ -10,7 +10,8 @@ CREATE VIEW hubspot.contact_property_update AS (
     -- we will never remove the `Teacher` status from a contact. The upside is
     -- we will update far fewer records, which should happen quicker.
     JOIN lms.users ON
-        contacts.email = users.email
+        -- Emails in the contacts table are already stored as lower case
+        contacts.email = LOWER(users.email)
         -- We definitely want to NOT join onto student information to keep that
         -- out of Hubspot
         AND users.is_teacher = True

--- a/report/data_tasks/report/refresh_contacts/01_hubspot_import_contacts.py
+++ b/report/data_tasks/report/refresh_contacts/01_hubspot_import_contacts.py
@@ -3,7 +3,11 @@ import os
 from report.data_sources.hubspot.client import Field, HubspotClient
 from report.data_sources.hubspot.sql import import_to_table
 
-CONTACT_FIELDS = (Field("hs_object_id", "id", mapping=int), Field("email"))
+CONTACT_FIELDS = (
+    Field("hs_object_id", "id", mapping=int),
+    # Lower case the email as we store it to simplify comparisons
+    Field("email", mapping=lambda email: email.lower()),
+)
 
 
 def main(connection, **kwargs):


### PR DESCRIPTION
I think this is potentially overkill, but it's good belt and braces. There are more fancy ways of doing a case insensitive column in Postgres, but this is simple, and will be performant enough. We aren't making use of any indexes here anyway and it still runs in a few seconds.

## Testing notes

You should have a set of updates in LMS and H from the reporting system by now. Make sure all the services are running then:

 * Run the `create_from_scratch` job
 * And the `refresh_contacts` job
 * Nothing should break
 * It should list one contact updating