### PR TITLE
Use a search based method to retrieve relevant contacts from HS

### DIFF
--- a/report/data_sources/chunk.py
+++ b/report/data_sources/chunk.py
@@ -1,0 +1,21 @@
+from itertools import islice
+from typing import Iterable
+
+
+def chunk(items: Iterable, chunk_size: int):
+    """Return items in multiple chunks of a maximum size.
+
+    :param items: Items to break into chunks
+    :param chunk_size: The maximum size of a chunk (last may be shorter)
+
+    :raises ValueError: If `chunk_size` is not a positive integer
+    """
+    if chunk_size < 1:
+        raise ValueError(f"Invalid chunk size: {chunk_size}")
+
+    # Create an iterable we can consume from
+    iter_items = iter(items)
+    # Use the two-argument form of iter to specify when to stop. This will
+    # cause iter to call the lambda until it returns an empty tuple, which
+    # should consume the iterable above.
+    return iter(lambda: tuple(islice(iter_items, chunk_size)), ())

--- a/report/data_sources/chunk.py
+++ b/report/data_sources/chunk.py
@@ -19,3 +19,32 @@ def chunk(items: Iterable, chunk_size: int):
     # cause iter to call the lambda until it returns an empty tuple, which
     # should consume the iterable above.
     return iter(lambda: tuple(islice(iter_items, chunk_size)), ())
+
+
+def chunk_with_max_len(items: Iterable[str], chunk_size: int, max_chars: int):
+    """Return items in chunks with a maximum size and char length.
+
+    :param items: Items to break into chunks
+    :param max_chars: Maximum total char length of a single chunk
+    :param chunk_size: The maximum size of a chunk
+
+    :raises ValueError: If `chunk_size` or `max_chars` is not a positive integer
+    """
+    if chunk_size < 1:
+        raise ValueError(f"Invalid chunk size: {chunk_size}")
+
+    if max_chars < 1:
+        raise ValueError(f"Invalid max chars: {max_chars}")
+
+    batch, batch_chars = [], 0
+
+    for item in items:
+        batch_chars += len(item)
+        if batch and batch_chars >= max_chars or len(batch) >= chunk_size:
+            yield batch
+            batch, batch_chars = [], 0
+
+        batch.append(item)
+
+    if batch:
+        yield batch

--- a/report/data_sources/hubspot/client.py
+++ b/report/data_sources/hubspot/client.py
@@ -3,11 +3,12 @@ import json
 import os.path
 from dataclasses import dataclass
 from enum import Enum
-from itertools import islice
 from typing import Callable, Generator, Iterable, List, Optional, Set
 
 from hubspot import HubSpot
 from hubspot.crm.associations import BatchInputPublicObjectId
+
+from report.data_sources.chunk import chunk
 
 
 @dataclass
@@ -21,21 +22,6 @@ class Field:
     def __post_init__(self):
         if not self.key:
             self.key = self.hs_field
-
-
-def chunk(items: Iterable, chunk_size: int):
-    """Return items in multiple chunks of a maximum size.
-
-    :param items: Items to break into chunks
-    :param chunk_size: The maximum size of a chunk (last may be shorter)
-    """
-
-    # Create an iterable we can consume from
-    iter_items = iter(items)
-    # Use the two-argument form of iter to specify when to stop. This will
-    # cause iter to call the lambda until it returns an empty tuple, which
-    # should consume the iterable above.
-    return iter(lambda: tuple(islice(iter_items, chunk_size)), ())
 
 
 @dataclass

--- a/report/data_tasks/report/refresh_contacts/01_hubspot_import_contacts.py
+++ b/report/data_tasks/report/refresh_contacts/01_hubspot_import_contacts.py
@@ -1,5 +1,7 @@
 import os
 
+from data_tasks.sql_query import SQLQuery
+
 from report.data_sources.hubspot.client import Field, HubspotClient
 from report.data_sources.hubspot.sql import import_to_table
 
@@ -13,8 +15,25 @@ CONTACT_FIELDS = (
 def main(connection, **kwargs):
     api_client = HubspotClient(private_app_key=os.environ["HUBSPOT_API_KEY"])
 
+    print("Search for emails for contacts to look up")
+    query = SQLQuery(
+        0,
+        """
+        SELECT DISTINCT(LOWER(email))
+        FROM lms.users
+        WHERE
+            email IS NOT NULL
+            AND email <> ''
+            AND is_teacher IS true
+        """,
+    )
+    query.execute(connection)
+    emails = [row[0] for row in query.rows]
+
     print("Getting Hubspot contact data...")
-    contacts = list(api_client.get_contacts(CONTACT_FIELDS))
+    contacts = list(
+        api_client.get_contacts_by_email(emails=emails, fields=CONTACT_FIELDS)
+    )
 
     import_to_table(
         connection=connection,

--- a/tests/unit/report/data_sources/chunk_test.py
+++ b/tests/unit/report/data_sources/chunk_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from report.data_sources.chunk import chunk
+
+
+class TestChunk:
+    @pytest.mark.parametrize(
+        "items,chunks",
+        (
+            ([1, 2, 3, 4, 5], [[1, 2], [3, 4], [5]]),
+            ([1, 2, 3, 4], [[1, 2], [3, 4]]),
+            ([], []),
+        ),
+    )
+    def test_it(self, items, chunks):
+        result = chunk(items, chunk_size=2)
+
+        assert [list(item) for item in result] == chunks
+
+    @pytest.mark.parametrize("chunk_size", (0, -1))
+    def test_it_rejects_silly_values(self, chunk_size):
+        with pytest.raises(ValueError):
+            list(chunk([], chunk_size=chunk_size))

--- a/tests/unit/report/data_sources/chunk_test.py
+++ b/tests/unit/report/data_sources/chunk_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from report.data_sources.chunk import chunk
+from report.data_sources.chunk import chunk, chunk_with_max_len
 
 
 class TestChunk:
@@ -21,3 +21,35 @@ class TestChunk:
     def test_it_rejects_silly_values(self, chunk_size):
         with pytest.raises(ValueError):
             list(chunk([], chunk_size=chunk_size))
+
+
+class TestChunkWithMaxLen:
+    @pytest.mark.parametrize(
+        "items,chunks",
+        (
+            (["1", "2", "3", "4", "5"], [["1", "2"], ["3", "4"], ["5"]]),
+            (["1", "2", "3", "4"], [["1", "2"], ["3", "4"]]),
+            ([], []),
+        ),
+    )
+    def test_it(self, items, chunks):
+        result = chunk_with_max_len(items, chunk_size=2, max_chars=10)
+
+        assert [list(item) for item in result] == chunks
+
+    def test_it_with_long_items(self):
+        result = chunk_with_max_len(
+            ["12345", "a", "abcdefghij"], chunk_size=10, max_chars=5
+        )
+
+        assert [list(item) for item in result] == [["12345"], ["a"], ["abcdefghij"]]
+
+    @pytest.mark.parametrize("chunk_size", (0, -1))
+    def test_it_rejects_silly_chunk_size_values(self, chunk_size):
+        with pytest.raises(ValueError):
+            list(chunk_with_max_len([], max_chars=1, chunk_size=chunk_size))
+
+    @pytest.mark.parametrize("max_chars", (0, -1))
+    def test_it_rejects_silly_max_chars_values(self, max_chars):
+        with pytest.raises(ValueError):
+            list(chunk_with_max_len([], max_chars=max_chars, chunk_size=1))


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/216

This means we find the contacts we need to update, rather than all of them. This should be much faster (2 minutes vs 35). This does mean we cannot update people who we no longer match.

## Constraints

We are using the search method. This seems to have the following limits:

 * 100 items per page for pagination
 * 100 items in an IN statement
 * 3000 characters per request body
 * 10 requests per second