### PR TITLE
Count assignment types by organization

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -27,6 +27,7 @@ CREATE TYPE report.academic_timescale AS ENUM (
     ) FROM SERVER "{{server_name}}" INTO {{schema_name}};
 
     IMPORT FOREIGN SCHEMA "report" LIMIT TO (
+        assignments,
         events,
         groups,
         group_bubbled_activity,
@@ -35,6 +36,7 @@ CREATE TYPE report.academic_timescale AS ENUM (
         group_roles,
         organization,
         organization_activity,
+        organization_assignments,
         organization_roles,
         users,
         users_sensitive

--- a/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/01_assignments/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/01_assignments/01_create_view.sql
@@ -1,0 +1,21 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.assignments CASCADE;
+
+CREATE MATERIALIZED VIEW lms.assignments AS (
+    SELECT
+        CONCAT('us-', id) AS id,
+        url,
+        file_type,
+        created,
+        updated
+    FROM lms_us.assignments
+
+    UNION ALL
+
+    SELECT
+        CONCAT('ca-', id) AS id,
+        url,
+        file_type,
+        created,
+        updated
+    FROM lms_ca.assignments
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/01_assignments/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/01_assignments/02_initial_fill.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS lms.assignments_id_idx;
+
+REFRESH MATERIALIZED VIEW lms.assignments;
+
+ANALYSE lms.assignments;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX assignments_id_idx ON lms.assignments (id);

--- a/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/02_organization_assignments/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/02_organization_assignments/01_create_view.sql
@@ -1,0 +1,15 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.organization_assignments CASCADE;
+
+CREATE MATERIALIZED VIEW lms.organization_assignments AS (
+    SELECT
+        CONCAT('us-', organization_id) AS organization_id,
+        CONCAT('us-', assignment_id) AS assignment_id
+    FROM lms_us.organization_assignments
+
+    UNION ALL
+
+    SELECT
+        CONCAT('ca-', organization_id) AS organization_id,
+        CONCAT('ca-', assignment_id) AS assignment_id
+    FROM lms_ca.organization_assignments
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/02_organization_assignments/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/02_organization_assignments/02_initial_fill.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS lms.assignments_organization_id_assignment_id_idx;
+
+REFRESH MATERIALIZED VIEW lms.organization_assignments;
+
+ANALYSE lms.organization_assignments;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX assignments_organization_id_assignment_id_idx ON lms.organization_assignments (organization_id, assignment_id);

--- a/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/03_organization_assignment_types/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/03_organization_assignment_types/01_create_view.sql
@@ -1,0 +1,27 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.organization_assignment_types CASCADE;
+
+CREATE MATERIALIZED VIEW lms.organization_assignment_types AS (
+    WITH aggregates AS (
+        SELECT
+            organization_assignments.organization_id,
+            assignments.file_type,
+            COUNT(1) AS count
+        FROM lms.organization_assignments
+        JOIN lms.assignments ON
+            assignments.id = organization_assignments.assignment_id
+        GROUP BY
+            organization_assignments.organization_id,
+            assignments.file_type
+    )
+
+    SELECT
+        aggregates.*,
+        -- Include the public id as it's very convenient to filter by
+        organizations.public_id
+    FROM aggregates
+    JOIN lms.organizations ON
+        organizations.id = aggregates.organization_id
+    ORDER BY
+        aggregates.organization_id,
+        count DESC
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/03_organization_assignment_types/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/06_assignments/03_organization_assignment_types/02_initial_fill.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS lms.organization_assignment_types_organization_id_file_type_idx;
+
+REFRESH MATERIALIZED VIEW lms.organization_assignment_types;
+
+ANALYSE lms.organization_assignment_types;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX organization_assignment_types_organization_id_file_type_idx ON lms.organization_assignment_types (organization_id, file_type);

--- a/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
@@ -24,3 +24,12 @@ ANALYSE lms.group_roles;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_roles;
 ANALYSE lms.organization_roles;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.assignments;
+ANALYSE lms.assignments;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_assignments;
+ANALYSE lms.organization_assignments;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_assignment_types;
+ANALYSE lms.organization_assignment_types;

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,8 @@ setenv =
     # happen inside docker, so we use docker names here
     H_US_DATABASE_URL = {env:H_US_DATABASE_URL:postgresql://report-fdw:password@h_postgres_1:5432/postgres}
     H_CA_DATABASE_URL = {env:H_CA_DATABASE_URL:postgresql://report-fdw:password@h_postgres_1:5432/postgres}
-    LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://report-fdw:password@lms_postgres_1:5432/postgres}
-    LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://report-fdw:password@lms_postgres_1:5432/postgres}
+    LMS_US_DATABASE_URL = {env:LMS_US_DATABASE_URL:postgresql://report-fdw:password@lms-postgres-1:5432/postgres}
+    LMS_CA_DATABASE_URL = {env:LMS_CA_DATABASE_URL:postgresql://report-fdw:password@lms-postgres-1:5432/postgres}
     # Used when testing tasks via `tox`:
     dev: NEW_RELIC_APP_NAME = {env: NEW_RELIC_APP_NAME:report}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/230

Pull through and combine assignment information from LMS. We need this specifically now to sum up the types used per organization, but we could easily want this for other things too.

## Testing notes

 * Start LMS and friends
 * To fill out some assignments visit:
    * https://hypothesis.instructure.com/courses/125/assignments/873
    * https://hypothesis.instructure.com/courses/125/assignments/876
    * https://hypothesis.instructure.com/courses/125/assignments/875
 * Follow: https://stackoverflowteams.com/c/hypothesis/questions/513/514#514
 * `make sql`
 * `SELECT * FROM lms.organization_assignment_types;`
 * You should see some rows (duplicated as we use the same LMS for CA and US)