### PR TITLE
Add extra fields to the user record to allow more HS automation

### DIFF
--- a/report/data_tasks/report/create_from_scratch/04_lms/04_users/01_users/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_users/01_users/01_create_view.sql
@@ -9,7 +9,8 @@ CREATE MATERIALIZED VIEW lms.users AS (
             email,
             username,
             is_teacher,
-            registered_date
+            first_active_date,
+            last_active_date
         FROM lms_us.users
 
         UNION ALL
@@ -20,7 +21,8 @@ CREATE MATERIALIZED VIEW lms.users AS (
             email,
             username,
             is_teacher,
-            registered_date
+            first_active_date,
+            last_active_date
         FROM lms_ca.users
     ) AS data
     ORDER BY id

--- a/report/data_tasks/report/create_from_scratch/99_hubspot_write/02_contact_property_update/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/99_hubspot_write/02_contact_property_update/01_create_view.sql
@@ -5,18 +5,20 @@ CREATE VIEW hubspot.contact_property_update AS (
     WITH contact_users AS (
         SELECT
             contacts.id AS hs_object_id,
-            -- This is a little confusing, but the id here comes from H
-            -- originally, but is just processed through the LMS reporting system
-            MAX(users.id) AS h_user_id
+            -- This is a little confusing, as the id here comes from H,
+            -- but is just processed through the LMS reporting system
+            MAX(users.id) AS h_user_id,
+            MAX(users.last_active_date) AS lms_last_active
         FROM hubspot.contacts
-        -- We are going to assume people never _stop_ being a teacher. This means
-        -- we will never remove the `Teacher` status from a contact. The upside is
-        -- we will update far fewer records, which should happen quicker.
+        -- We are going to assume people never _stop_ being a teacher. This
+        -- means we will never remove the `Teacher` status from a contact. The
+        -- upside is we will update far fewer records, which should happen
+        -- quicker.
         JOIN lms.users ON
             -- Emails in the contacts table are already stored as lower case
             contacts.email = LOWER(users.email)
-            -- We definitely want to NOT join onto student information to keep that
-            -- out of Hubspot
+            -- We definitely want to NOT join onto student information to keep
+            -- that out of Hubspot
             AND users.is_teacher = True
         GROUP BY contacts.id
     )
@@ -24,6 +26,30 @@ CREATE VIEW hubspot.contact_property_update AS (
     SELECT
         contact_users.hs_object_id,
         contact_users.h_user_id,
-        'Teacher' AS lms_role
+        'Teacher' AS lms_role,
+        contact_users.lms_last_active,
+        COALESCE(course_activity.lms_annotations_this_semester, 0) AS lms_annotations_this_semester,
+        CURRENT_DATE AS reporting_last_update
     FROM contact_users
+
+    LEFT OUTER JOIN (
+        SELECT
+            user_id,
+            SUM(annotation_count) AS lms_annotations_this_semester
+        FROM lms.users
+        JOIN lms.group_roles ON
+            group_roles.user_id = users.id
+            AND group_roles.role = 'teacher'
+        JOIN lms.group_bubbled_activity ON
+            group_bubbled_activity.group_id = group_roles.group_id
+            AND group_bubbled_activity.created_week >= report.multi_truncate('semester', CURRENT_DATE)
+        JOIN lms.groups ON
+            -- We are limiting by courses, because we want to count courses. We
+            -- still get the right counts for non-unique items by using the
+            -- bubbled version of the table
+            groups.id = group_roles.group_id
+            AND groups.group_type = 'course'
+        GROUP BY user_id
+    ) AS course_activity ON
+        course_activity.user_id = contact_users.h_user_id
 );


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/product-backlog/issues/1460

Requires:

 * https://github.com/hypothesis/report/pull/236
 * https://github.com/hypothesis/lms/pull/5502

This should allow us to:

 * Retire some of the manual processes being done
 * Enable linking back to the dashboards in Report
 * Answer the current questions linked in [this PRD](https://docs.google.com/document/d/16EhZf83rP2yU6PasLEsIoa6S_-cApTcHPYG24FNCOcE/edit)

## Questions we are attempting to answer

Membership duration:

 * When did they become a user? (created)
 * Did they launch in the current semester? (updated)
 * How long have they been a user? (updated - created)

Annotation activity in related courses:

 * How much annotation is happening in their courses? (anno count)
 * How would we classify their level of use? (anno count / classified into buckets)
 * Is this happening in a single course or multiple courses? (course count)

## Do not merge!

We need to update the required fields in Hubspot for this to work, otherwise we get an error like this:

> HTTP response body: {"status":"error","message":"The following property names are invalid: [lms_first_login, lms_last_login, lms_active_courses_this_semester, lms_annotations_this_semester, lms_reporting_semester, h_user_id].","correlationId":"...","context":{"invalidProperties":["lms_first_login","lms_last_login","lms_active_courses_this_semester","lms_annotations_this_semester","lms_reporting_semester","h_user_id"]},"category":"VALIDATION_ERROR","subCategory":"ImportRequestValidatorError.INVALID_PROPERTY_NAMES"}

## Fields

| Field                              | Example | Definition                                  | Purpose                                                     |
|---------------------------|---------|---------------------------------------------|-------------------------------------------------------------|     
| `lms_last_active`  |  `2022-01-02`                | Last known hint of activity                      | Recency of activity |
| `lms_annotations_this_semester`    | `106` | Annotations for groups linked to this user  | Measure of quantity of activity                             |
| `reporting_last_update`   | `2022-01-02`        | Static value based on NOW                   | Allows us to check for users who have not been updated by reporting    |

## Testing notes

You can't test the whole thing right now, but you can:

 * Start all the things
 * Login as `eng+canvasteacher@hypothes.is`
 * To: https://hypothesis.instructure.com/courses/125/assignments/874
 * Make an annotation
 * Follow https://stackoverflowteams.com/c/hypothesis/questions/513
 * Run the create from scratch with `--no-python` (or not if you want to test sending to Hubspot as well)

 