### PR TITLE
Update reporting with the new "submission" event type

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -7,7 +7,11 @@ CREATE TYPE report.roles AS ENUM (
 
 DROP TYPE IF EXISTS report.event_type CASCADE;
 CREATE TYPE report.event_type AS ENUM (
-    'configured_launch', 'deep_linking', 'audit', 'edited_assignment'
+    'configured_launch',
+    'deep_linking',
+    'audit',
+    'edited_assignment',
+    'submission'
 );
 
 DROP TYPE IF EXISTS report.academic_timescale CASCADE;


### PR DESCRIPTION
From:

 * https://github.com/hypothesis/lms/pull/5504

We need to update the reporting types to match the new possible values in the event table. This can be released before the new event type safely, but reporting will fail if run after.