### PR TITLE
Add annotation counts for users and groups by various facets

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -35,6 +35,8 @@ CREATE TYPE report.annotation_sub_type AS ENUM (
         assignments,
         events,
         groups,
+        group_annotation_counts,
+        group_bubbled_annotation_counts,
         group_bubbled_activity,
         group_bubbled_counts,
         group_bubbled_type_counts,
@@ -45,6 +47,7 @@ CREATE TYPE report.annotation_sub_type AS ENUM (
         organization_assignments,
         organization_annotation_types,
         organization_roles,
+        user_annotation_counts,
         users,
         users_sensitive
     ) FROM SERVER "{{server_name}}" INTO {{schema_name}};

--- a/report/data_tasks/report/create_from_scratch/04_lms/03_groups/05_group_bubbled_annotation_counts/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/03_groups/05_group_bubbled_annotation_counts/01_create_view.sql
@@ -1,0 +1,23 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.group_bubbled_annotation_counts CASCADE;
+
+CREATE MATERIALIZED VIEW lms.group_bubbled_annotation_counts AS (
+    SELECT
+        created_week,
+        CONCAT('us-', group_id) as group_id,
+        role,
+        sub_type,
+        shared,
+        count
+    FROM lms_us.group_bubbled_annotation_counts
+
+    UNION ALL
+
+    SELECT
+        created_week,
+        CONCAT('ca-', group_id) as group_id,
+        role,
+        sub_type,
+        shared,
+        count
+    FROM lms_ca.group_bubbled_annotation_counts
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/03_groups/05_group_bubbled_annotation_counts/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/03_groups/05_group_bubbled_annotation_counts/02_initial_fill.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS lms.group_bubbled_annotation_counts_group_id_sub_type_shared_idx;
+
+REFRESH MATERIALIZED VIEW lms.group_bubbled_annotation_counts;
+
+ANALYSE lms.group_bubbled_annotation_counts;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX group_bubbled_annotation_counts_group_id_sub_type_shared_idx
+    ON lms.group_bubbled_annotation_counts (group_id, role, sub_type, shared, created_week);

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_users/04_user_annotation_counts/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_users/04_user_annotation_counts/01_create_view.sql
@@ -1,0 +1,23 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.user_annotation_counts CASCADE;
+
+CREATE MATERIALIZED VIEW lms.user_annotation_counts AS (
+    SELECT
+        created_week,
+        CONCAT('us-', user_id) as user_id,
+        CONCAT('us-', group_id) as group_id,
+        sub_type,
+        shared,
+        count
+    FROM lms_us.user_annotation_counts
+
+    UNION ALL
+
+    SELECT
+        created_week,
+        CONCAT('ca-', user_id) as user_id,
+        CONCAT('ca-', group_id) as group_id,
+        sub_type,
+        shared,
+        count
+    FROM lms_ca.user_annotation_counts
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/04_users/04_user_annotation_counts/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/04_users/04_user_annotation_counts/02_initial_fill.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS lms.user_annotation_counts_group_id_sub_type_shared_idx;
+
+REFRESH MATERIALIZED VIEW lms.user_annotation_counts;
+
+ANALYSE lms.user_annotation_counts;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX user_annotation_counts_group_id_sub_type_shared_idx
+    ON lms.user_annotation_counts (user_id, group_id, sub_type, shared, created_week);

--- a/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
@@ -22,6 +22,9 @@ ANALYSE lms.organization_group;
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.group_bubbled_type_counts;
 ANALYSE lms.group_bubbled_type_counts;
 
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.group_bubbled_annotation_counts;
+ANALYSE lms.group_bubbled_annotation_counts;
+
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.users;
 ANALYSE lms.users;
 
@@ -30,6 +33,9 @@ ANALYSE lms.group_roles;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_roles;
 ANALYSE lms.organization_roles;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.user_annotation_counts;
+ANALYSE lms.user_annotation_counts;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.assignments;
 ANALYSE lms.assignments;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/235

Requires:

 * https://github.com/hypothesis/lms/pull/5515

This combines the bubbled group counts from LMS and also exposes the user counts (because I think we'll want them in the user dash).

## This PR adds

 * `user_annotation_counts`
 * `group_bubbled_annotation_counts`

These should allow us to slice and dice annotation counts for these entities in a number of different ways

## Testing notes

 * Start all the things and make some annotations as both a teacher and student
 * Follow: https://stackoverflowteams.com/c/hypothesis/questions/513
 * Use your DB viewer of choice to see the resulting tables
 * **Note**: Report uses the US DB as the CA DB as well, so expect doubled up records