### PR TITLE
Expose the organization annotation counts view for reporting

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -48,6 +48,7 @@ CREATE TYPE report.annotation_sub_type AS ENUM (
         organization,
         organization_activity,
         organization_assignments,
+        organization_annotation_counts,
         organization_annotation_types,
         organization_roles,
         user_annotation_counts,

--- a/report/data_tasks/report/create_from_scratch/04_lms/01_organization/04_organization_annotation_counts/01_create_view.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/01_organization/04_organization_annotation_counts/01_create_view.sql
@@ -1,0 +1,29 @@
+DROP MATERIALIZED VIEW IF EXISTS lms.organization_annotation_counts CASCADE;
+
+CREATE MATERIALIZED VIEW lms.organization_annotation_counts AS (
+    SELECT
+        timescale,
+        start_date,
+        end_date,
+        period,
+        CONCAT('us-', organization_id) AS organization_id,
+        role,
+        sub_type,
+        shared,
+        count
+    FROM lms_us.organization_annotation_counts
+
+    UNION ALL
+
+    SELECT
+        timescale,
+        start_date,
+        end_date,
+        period,
+        CONCAT('ca-', organization_id) AS organization_id,
+        role,
+        sub_type,
+        shared,
+        count
+    FROM lms_ca.organization_annotation_counts
+) WITH NO DATA;

--- a/report/data_tasks/report/create_from_scratch/04_lms/01_organization/04_organization_annotation_counts/02_initial_fill.sql
+++ b/report/data_tasks/report/create_from_scratch/04_lms/01_organization/04_organization_annotation_counts/02_initial_fill.sql
@@ -1,0 +1,12 @@
+DROP INDEX IF EXISTS lms.organization_annotation_counts_timescale_period_idx;
+DROP INDEX IF EXISTS lms.organization_annotation_type_start_date_end_date_idx;
+
+REFRESH MATERIALIZED VIEW lms.organization_annotation_counts;
+
+ANALYSE lms.organization_annotation_counts;
+
+-- A unique index is mandatory for concurrent updates used in the refresh
+CREATE UNIQUE INDEX organization_annotation_counts_timescale_period_idx
+    ON lms.organization_annotation_counts (timescale, period, organization_id, role, sub_type, shared);
+CREATE INDEX organization_annotation_counts_start_date_end_date_idx
+    ON lms.organization_annotation_counts (start_date, end_date);

--- a/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
@@ -42,3 +42,6 @@ ANALYSE lms.organization_assignments;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_assignment_types;
 ANALYSE lms.organization_assignment_types;
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_assignment_counts;
+ANALYSE lms.organization_assignment_counts;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/235

This exposes the `organization_annotation_counts` view, which is a more capable replacement for the `organization_annotation_types` view, which is being refactored out.