### PR TITLE
Fix a "fix" for the organization types

### DIFF
--- a/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
+++ b/report/data_tasks/report/refresh/03_lms/01_materialized_views_refresh.sql
@@ -4,8 +4,8 @@ ANALYSE lms.organizations;
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_activity;
 ANALYSE lms.organization_activity;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_annotation_types;
-ANALYSE lms.organization_annotation_types;
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_annotation_counts;
+ANALYSE lms.organization_annotation_counts;
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.events;
 ANALYSE lms.events;
@@ -40,5 +40,5 @@ ANALYSE lms.assignments;
 REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_assignments;
 ANALYSE lms.organization_assignments;
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_annotation_counts;
-ANALYSE lms.organization_annotation_counts;
+REFRESH MATERIALIZED VIEW CONCURRENTLY lms.organization_assignment_types;
+ANALYSE lms.organization_assignment_types;


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/report/issues/235

I got mixed up and removed the wrong refresh. There was a view called `organization_assignment_types`... I missed.

I've double checked over the list of refreshing views and I think they all match the layout of the create now.