### PR TITLE
Fix a typo in the event type enum

### DIFF
--- a/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
+++ b/report/data_tasks/report/create_from_scratch/00_schema/04_create_fdw_schema_lms.jinja2.sql
@@ -12,7 +12,7 @@ CREATE TYPE report.event_type AS ENUM (
     'audit',
     'edited_assignment',
     'submission',
-    'grade',
+    'grade'
 );
 
 DROP TYPE IF EXISTS report.academic_timescale CASCADE;


### PR DESCRIPTION
Missed this on the review. Trailing commas are not ok