### PR TITLE
Upgrade metabase to 0.45.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --virtual build-deps \
   && apk del build-deps
 
 
-FROM metabase/metabase:v0.45.1
+FROM metabase/metabase:v0.45.4.1
 
 # Copy the python binaries and libraries from the python image
 # The metabase image is based on a newer alpine and the python package there


### PR DESCRIPTION
Metabase released a security notification advising people to upgrade immediately:

https://github.com/metabase/metabase/releases/tag/v0.45.4.1

Part of the work towards:
- https://github.com/hypothesis/playbook/issues/1255