### PR TITLE
Upgrade metabase to 0.45.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --virtual build-deps \
   && apk del build-deps
 
 
-FROM metabase/metabase:v0.45.4.1
+FROM metabase/metabase:v0.45.4.2
 
 # Copy the python binaries and libraries from the python image
 # The metabase image is based on a newer alpine and the python package there


### PR DESCRIPTION
Original version: `0.45.4.1`
New version: `0.45.4.2`

Upgrading due to a bug with Google Sign-In.
- https://github.com/metabase/metabase/issues/32602

The change is small and requires no schema updates.
- https://github.com/metabase/metabase/compare/v0.45.4.1...v0.45.4.2