### PR TITLE
Allow optional attributes to be entirely absent from HubSpot

### DIFF
--- a/report/data_sources/hubspot/client.py
+++ b/report/data_sources/hubspot/client.py
@@ -338,7 +338,7 @@ class HubspotClient:
     def _map_item(cls, item, fields: Iterable[Field]):
         result = {}
         for field in fields:
-            value = item.properties[field.hs_field] or None
+            value = item.properties.get(field.hs_field) or None
             if value and field.mapping:
                 value = field.mapping(value)
 


### PR DESCRIPTION
Fixes: https://hypothesis.sentry.io/issues/4788397766/?environment=prod&project=4504163606790144&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

