### PR TITLE
Allow certain types in the HS import to be timestamps or dates

### DIFF
--- a/report/data_sources/hubspot/client.py
+++ b/report/data_sources/hubspot/client.py
@@ -3,6 +3,7 @@ import json
 import os.path
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from http import HTTPStatus
 from typing import Callable, Generator, Iterable, List, Optional, Set
@@ -15,6 +16,20 @@ from hubspot.crm.objects.exceptions import ApiException
 from report.data_sources.chunk import chunk, chunk_with_max_len
 
 RATE_LIMIT_SECONDS = 5
+
+
+def date_or_timestamp(value):
+    """
+    Format either timestamp or already formatted dates as YYYY-MM-DD.
+
+    We seem to be getting different formats for the same fields,
+    coerce them to always be string formated dates.
+    """
+    try:
+        return datetime.fromtimestamp(int(value) / 1000).strftime("%Y-%m-%d")
+    except ValueError:
+        # Date is already formatted, return it verbatim
+        return value
 
 
 @dataclass

--- a/report/data_tasks/report/create_from_scratch/02_hubspot_read/02_data_import/01_hubspot_import.py
+++ b/report/data_tasks/report/create_from_scratch/02_hubspot_read/02_data_import/01_hubspot_import.py
@@ -1,7 +1,7 @@
 import os
 from operator import itemgetter
 
-from report.data_sources.hubspot.client import Field, HubspotClient
+from report.data_sources.hubspot.client import Field, HubspotClient, date_or_timestamp
 from report.data_sources.hubspot.sql import import_to_table
 
 # The API docs link you here, but it doesn't show the API keys for properties
@@ -16,8 +16,14 @@ COMPANY_FIELDS = (
     Field("hubspot_owner_id", "company_owner_id", mapping=int),
     Field("owner__success", "success_owner_id", mapping=int),
     # Cohort
-    Field("cohort__pilot_first_date", "cohort_pilot_first_date"),
-    Field("cohort__subscription_first_date", "cohort_subscription_first_date"),
+    Field(
+        "cohort__pilot_first_date", "cohort_pilot_first_date", mapping=date_or_timestamp
+    ),
+    Field(
+        "cohort__subscription_first_date",
+        "cohort_subscription_first_date",
+        mapping=date_or_timestamp,
+    ),
     # Deals
     Field("current_deal__services_start", "current_deal_services_start"),
     Field("current_deal__services_end", "current_deal_services_end"),

--- a/tests/unit/report/data_sources/hubspot/client_test.py
+++ b/tests/unit/report/data_sources/hubspot/client_test.py
@@ -14,12 +14,24 @@ from hubspot.crm.contacts import Filter, FilterGroup, PublicObjectSearchRequest
 from hubspot.crm.objects.exceptions import ApiException
 from pytest import fixture
 
-from report.data_sources.hubspot.client import RATE_LIMIT_SECONDS, Field, HubspotClient
+from report.data_sources.hubspot.client import (
+    RATE_LIMIT_SECONDS,
+    Field,
+    HubspotClient,
+    date_or_timestamp,
+)
 
 
 @dataclass
 class FakeApiObject:
     properties: dict
+
+
+@pytest.mark.parametrize(
+    "value,expected", [("2019-03-01", "2019-03-01"), ("1551398400000", "2019-03-01")]
+)
+def test_date_or_timestamp(value, expected):
+    assert date_or_timestamp(value) == expected
 
 
 class TestField:


### PR DESCRIPTION
Fixes: https://hypothesis.sentry.io/issues/4798946342/?project=4504163606790144&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

We seen this value in the wild, convert timestamp to dates to avoid having to parametrize the resulting SQL.