### PR TITLE
Require libexpat in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=python /usr/local/lib/libpython3.so /usr/local/lib/libpython3.so
 COPY --from=python /usr/local/bin/newrelic-admin /usr/local/bin/newrelic-admin
 
 # We need to install some package that are not present in the metabase image
-RUN apk add libpq 
+RUN apk add libpq libexpat=2.6.3-r0
 
 # Create the report user, group, home directory and package directory.
 RUN addgroup -S report \


### PR DESCRIPTION
https://github.com/hypothesis/report/pull/407 fixed building the docker image but it broke running the app inside it.


We had to previously add the dependency here https://github.com/hypothesis/report/pull/369 


### Testing

- docker compose build; make services
- docker exec -it report-metabase-1 python
- `>>> import pyexpat`

This fails in `main`, is successful here.