### PR TITLE
Remove the explicit dependency libexpat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=python /usr/local/lib/libpython3.so /usr/local/lib/libpython3.so
 COPY --from=python /usr/local/bin/newrelic-admin /usr/local/bin/newrelic-admin
 
 # We need to install some package that are not present in the metabase image
-RUN apk add libpq libexpat=2.6.3-r0
+RUN apk add libpq
 
 # Create the report user, group, home directory and package directory.
 RUN addgroup -S report \


### PR DESCRIPTION
This is causing:

ERROR: unable to select packages:
  libexpat-2.5.0-r2:

  breaks: world[libexpat=2.6.3-r0]
  satisfies: fontconfig-2.14.2-r4[so:libexpat.so.1]

The dependency was added a while back in:

https://github.com/hypothesis/report/pull/369 as it seemed to be missing

from the docker image but it's not a problem anymore.


More info also on:

- https://github.com/python/cpython/issues/117173


### Testing

- We can the the image does build now:


```docker compose build```

successful on this branch, fails on `main`.


- While the c library are not explicit installed on the image the python one is working:


```
docker exec -it report-metabase-1 python
Python 3.11.10 (main, Nov 12 2024, 02:18:01) [GCC 13.2.1 20231014] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyexpat
```