### PR TITLE
Enable Sentry's "releases" feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=python /usr/local/lib/libpython3.so /usr/local/lib/libpython3.so
 COPY --from=python /usr/local/bin/newrelic-admin /usr/local/bin/newrelic-admin
 
 # We need to install some package that are not present in the metabase image
-RUN apk add libpq
+RUN apk add libpq git
 
 # Create the report user, group, home directory and package directory.
 RUN addgroup -S report \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ source = ["report", "tests/unit"]
 omit = [
     "*/report/__main__.py",
     "*/report/app.py",
+    "*/report/_version.py",
 ]
 
 [tool.coverage.paths]

--- a/report/_version.py
+++ b/report/_version.py
@@ -1,0 +1,77 @@
+import datetime
+import subprocess
+from subprocess import DEVNULL
+
+# git-archive substitution markers. When this file is written out by a `git
+# archive` command, these will be replaced by the short commit hash and the
+# commit date, respectively.
+VERSION_GIT_REF = "$Format:%h$"
+VERSION_GIT_DATE = "$Format:%ct$"
+
+# Fallback version in case we cannot derive the version.
+VERSION_UNKNOWN = "0+unknown"
+
+
+def fetch_git_ref():
+    return subprocess.check_output(  # noqa: S603
+        ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
+        stderr=DEVNULL,
+    ).strip()
+
+
+def fetch_git_date(ref):
+    output = subprocess.check_output(
+        ["git", "show", "-s", "--format=%ct", ref]
+    )  # noqa: S603, S607
+    return datetime.datetime.fromtimestamp(int(output))  # noqa: DTZ006
+
+
+def fetch_git_dirty():
+    # Ensure git index is up-to-date first. This usually isn't necessary, but
+    # can be needed inside a docker container where the index is out of date.
+    subprocess.call(["git", "update-index", "-q", "--refresh"])  # noqa: S603, S607
+    dirty_tree = bool(
+        subprocess.call(["git", "diff-files", "--quiet"])
+    )  # noqa: S603, S607
+    dirty_index = bool(
+        subprocess.call(
+            ["git", "diff-index", "--quiet", "--cached", "HEAD"]
+        )  # noqa: S603, S607
+    )
+    return dirty_tree or dirty_index
+
+
+def git_version():
+    ref = fetch_git_ref()
+    date = fetch_git_date(ref)
+    dirty = fetch_git_dirty()
+    return pep440_version(date, ref, dirty)
+
+
+def git_archive_version():  # pragma: no cover
+    ref = VERSION_GIT_REF
+    date = datetime.datetime.fromtimestamp(int(VERSION_GIT_DATE))  # noqa: DTZ006
+    return pep440_version(date, ref)
+
+
+def pep440_version(date, ref, dirty=False):  # noqa: FBT002
+    """Build a PEP440-compliant version number from the passed information."""
+    return f"{date.strftime('%Y%m%d')}+g{ref}{'.dirty' if dirty else ''}"
+
+
+def get_version():  # pragma: no cover
+    """Fetch the current application version."""
+    # First we try to retrieve the current application version from git.
+    try:
+        return git_version()
+    except subprocess.CalledProcessError:
+        pass
+
+    # We are not in a git checkout or extracting the version from git failed,
+    # so we attempt to read a version written into the header of this file by
+    # `git archive`.
+    if not VERSION_GIT_REF.startswith("$"):
+        return git_archive_version()
+
+    # If neither of these strategies work, we fall back to VERSION_UNKNOWN.
+    return VERSION_UNKNOWN

--- a/report/sentry.py
+++ b/report/sentry.py
@@ -2,9 +2,16 @@ import os
 
 import sentry_sdk
 
+from report._version import get_version
+
 
 def load_sentry():
     """Load Sentry integration."""
 
     if sentry_dsn := os.environ.get("SENTRY_DSN"):
-        sentry_sdk.init(dsn=sentry_dsn)
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            # Enable Sentry's "Releases" feature, see:
+            # https://docs.sentry.io/platforms/python/configuration/options/#release
+            release=get_version(),
+        )

--- a/tests/unit/report/sentry_test.py
+++ b/tests/unit/report/sentry_test.py
@@ -6,12 +6,15 @@ from report.sentry import load_sentry
 
 
 class TestLoadSentry:
-    def test_it(self, os, sentry_sdk):
+    def test_it(self, os, sentry_sdk, get_version):
         os.environ = {"SENTRY_DSN": sentinel.sentry_dsn}
 
         load_sentry()
 
-        sentry_sdk.init.assert_called_once_with(dsn=sentinel.sentry_dsn)
+        sentry_sdk.init.assert_called_once_with(
+            dsn=sentinel.sentry_dsn,
+            release=get_version.return_value,
+        )
 
     def test_it_with_no_sentry_dsn(self, os, sentry_sdk):
         os.environ = {}
@@ -20,10 +23,17 @@ class TestLoadSentry:
 
         sentry_sdk.init.assert_not_called()
 
-    @pytest.fixture
-    def os(self, patch):
-        return patch("report.sentry.os")
 
-    @pytest.fixture
-    def sentry_sdk(self, patch):
-        return patch("report.sentry.sentry_sdk")
+@pytest.fixture(autouse=True)
+def os(patch):
+    return patch("report.sentry.os")
+
+
+@pytest.fixture(autouse=True)
+def sentry_sdk(patch):
+    return patch("report.sentry.sentry_sdk")
+
+
+@pytest.fixture(autouse=True)
+def get_version(patch):
+    return patch("report.sentry.get_version")


### PR DESCRIPTION
The releases feature is useful in itself, and this should also stop the
"discarded session update because of missing release" messages that
`sentry_sdk` is logging all the time.
