### PR TITLE
Don't let cookiecutter update `_version.py`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -7,6 +7,7 @@
     "conf/alembic.ini",
     "conf/supervisord.conf",
     "report/__main__.py",
+    "report/_version.py",
     "report/app.py",
     "report/core.py",
     "report/migrations/*",


### PR DESCRIPTION
The cookiecutter wants to reformat `_version.py` into a Ruff-compatible
format but this project still uses Black which is incompatible.
